### PR TITLE
fix: Add the endpoint for product variations

### DIFF
--- a/woocommerce_fusion/tasks/stock_update.py
+++ b/woocommerce_fusion/tasks/stock_update.py
@@ -109,7 +109,20 @@ def update_stock_levels_on_woocommerce_site(item_code):
 				}
 
 				try:
-					response = wc_api.put(endpoint=f"products/{woocommerce_id}", data=data_to_post)
+					parent_item_id = item.variant_of
+					if parent_item_id:
+						parent_item = frappe.get_doc("Item", parent_item_id)
+						# Get the parent item's woocommerce_id
+						for parent_wc_site in parent_item.woocommerce_servers:
+							if parent_wc_site.woocommerce_server == woocommerce_server:
+								parent_woocommerce_id = parent_wc_site.woocommerce_id
+								break
+						if not parent_woocommerce_id:
+							continue
+						endpoint = f"products/{parent_woocommerce_id}/variations/{woocommerce_id}"
+					else:
+						endpoint = f"products/{woocommerce_id}"
+					response = wc_api.put(endpoint=endpoint, data=data_to_post)
 				except Exception as err:
 					error_message = f"{frappe.get_traceback()}\n\nData in PUT request: \n{str(data_to_post)}"
 					frappe.log_error("WooCommerce Error", error_message)

--- a/woocommerce_fusion/tasks/test_stock_update.py
+++ b/woocommerce_fusion/tasks/test_stock_update.py
@@ -75,6 +75,63 @@ class TestWooCommerceStockSync(FrappeTestCase):
 		self.assertEqual(actual_put_endpoints, expected_put_endpoints)
 		self.assertEqual(actual_put_data, expected_put_data)
 
+	@patch("woocommerce_fusion.tasks.stock_update.frappe")
+	@patch("woocommerce_fusion.tasks.stock_update.APIWithRequestLogging", autospec=True)
+	def test_update_stock_levels_on_woocommerce_site_variant(self, mock_wc_api, mock_frappe):
+		# Set up a dummy variant item set to sync to a WC site
+		variant_item = frappe._dict(
+			woocommerce_servers=[
+				frappe._dict(woocommerce_id=101, woocommerce_server="woo1.example.com", enabled=1),
+			],
+			is_stock_item=1,
+			disabled=0,
+			variant_of="parent_item_code",
+		)
+		mock_frappe.get_doc.side_effect = [
+			variant_item,
+			frappe._dict(
+				woocommerce_servers=[
+					frappe._dict(woocommerce_id=100, woocommerce_server="woo1.example.com", enabled=1),
+				]
+			),
+		]
+
+		# Set up a dummy bin list with stock in two Warehouses
+		bin_list = [
+			frappe._dict(warehouse="Warehouse A", actual_qty=5),
+			frappe._dict(warehouse="Warehouse B", actual_qty=10),
+		]
+		mock_frappe.get_list.return_value = bin_list
+
+		# Set up mock return values
+		mock_frappe.get_cached_doc.return_value = frappe._dict(
+			woocommerce_server="woo1.example.com",
+			enable_sync=1,
+			enable_stock_level_synchronisation=1,
+			warehouses=[frappe._dict(warehouse="Warehouse A"), frappe._dict(warehouse="Warehouse B")],
+		)
+
+		# Mock out calls to WooCommerce API's
+		mock_put_response = Mock()
+		mock_put_response.status_code = 200
+
+		mock_api_instance = MagicMock()
+		mock_api_instance.put.return_value = mock_put_response
+		mock_wc_api.return_value = mock_api_instance
+
+		# Call function under test
+		update_stock_levels_on_woocommerce_site("variant_item_code")
+
+		# Assert that the inventories put calls were made with the correct arguments
+		self.assertEqual(mock_api_instance.put.call_count, 1)
+		actual_put_endpoint = mock_api_instance.put.call_args.kwargs["endpoint"]
+		actual_put_data = mock_api_instance.put.call_args.kwargs["data"]
+
+		expected_put_endpoint = "products/100/variations/101"
+		expected_data = {"stock_quantity": 15}
+		self.assertEqual(actual_put_endpoint, expected_put_endpoint)
+		self.assertEqual(actual_put_data, expected_data)
+
 	@patch("woocommerce_fusion.tasks.stock_update.frappe.db.get_all")
 	@patch("woocommerce_fusion.tasks.stock_update.frappe.enqueue")
 	def test_update_stock_levels_for_all_enabled_items_in_background(


### PR DESCRIPTION
## Description

There is an issue with the endpoint of variable product, according to [woocommerce api documentation](https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-product-variation) the endpoint changes. This causes the problem of not being able to sync stock with this type of products.

It should fix https://github.com/dvdl16/woocommerce_fusion/issues/127

## Type of change

- 🟢 Bug fix (change which fixes an issue)
- ⚪ New feature (change which adds functionality)
- ⚪ Breaking change (fix or feature that would cause existing functionality to not work as expected)