### PR TITLE
fix: Payment is not needed when total is 0

### DIFF
--- a/woocommerce_fusion/tasks/sync_sales_orders.py
+++ b/woocommerce_fusion/tasks/sync_sales_orders.py
@@ -281,6 +281,10 @@ class SynchroniseSalesOrder(SynchroniseWooCommerce):
 			and not sales_order.woocommerce_payment_entry
 			and sales_order.docstatus == 1
 		):
+			# If the grand total is 0, skip payment entry creation
+			if sales_order.grand_total == None or float(sales_order.grand_total) == 0:
+				return True
+
 			# Get Company Bank Account for this Payment Method
 			payment_method_bank_account_mapping = json.loads(wc_server.payment_method_bank_account_mapping)
 


### PR DESCRIPTION
## Description

Payment should not be created when the total on the order is 0. This commits avoid the creation. This should fix #181 

## Type of change

- 🟢 Bug fix (change which fixes an issue)
- ⚪ New feature (change which adds functionality)
- ⚪ Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Tests

- [x] [Unit Tests](https://frappeframework.com/docs/user/en/guides/automated-testing/unit-testing) have been updated or added, as required