### PR TITLE
Batch API (perf), version-16 support, sales order naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The code is licensed as GNU General Public License (v3) and the copyright is own
 
 ### Features
 
-WooCommerce connector for ERPNext v15
+WooCommerce connector for ERPNext v15 and v16
 
 This app allows you to synchronise your ERPNext site with **multiple** WooCommerce websites
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "flit_core.buildapi"
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
 hypothesis = "~=6.31.0"
-parameterized = "~=0.9.0 "
+parameterized = "~=0.9.0"
 
 [tool.ruff]
 line-length = 110

--- a/research.md
+++ b/research.md
@@ -1,0 +1,1073 @@
+# WooCommerce Fusion — Item & Item Price Sync: Deep Technical Research
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Architecture & Key Data Structures](#2-architecture--key-data-structures)
+3. [Item Sync — Trigger Points](#3-item-sync--trigger-points)
+4. [Item Sync — Core Logic: SynchroniseItem](#4-item-sync--core-logic-synchroniseitem)
+5. [Sync Direction & Conflict Resolution](#5-sync-direction--conflict-resolution)
+6. [ERPNext → WooCommerce: Create & Update](#6-erpnext--woocommerce-create--update)
+7. [WooCommerce → ERPNext: Create & Update](#7-woocommerce--erpnext-create--update)
+8. [Scheduled (Hourly) Item Sync](#8-scheduled-hourly-item-sync)
+9. [Item Price Sync — Architecture](#9-item-price-sync--architecture)
+10. [Item Price Sync — Core Logic: SynchroniseItemPrice](#10-item-price-sync--core-logic-synchroniseitemprice)
+11. [Field Mapping & JSONPath Integration](#11-field-mapping--jsonpath-integration)
+12. [WooCommerce API Layer](#12-woocommerce-api-layer)
+13. [Variant / Attribute Handling](#13-variant--attribute-handling)
+14. [Stock Level Sync (Related Context)](#14-stock-level-sync-related-context)
+15. [Configuration Reference](#15-configuration-reference)
+16. [Custom Fields Added to Standard DocTypes](#16-custom-fields-added-to-standard-doctypes)
+17. [Error Handling & Logging](#17-error-handling--logging)
+18. [UI Integration](#18-ui-integration)
+19. [End-to-End Sync Flow Diagrams](#19-end-to-end-sync-flow-diagrams)
+20. [Key Gotchas & Implementation Nuances](#20-key-gotchas--implementation-nuances)
+21. [File Location Reference](#21-file-location-reference)
+
+---
+
+## 1. Overview
+
+WooCommerce Fusion is a bidirectional synchronisation connector between **Frappe/ERPNext v15+** and **WooCommerce**. It supports syncing:
+
+- **Items / Products** — bidirectional, timestamp-based conflict resolution
+- **Item Prices** — ERPNext → WooCommerce (one-directional), price-list-based
+- **Stock Levels** — ERPNext → WooCommerce, triggered on stock document submissions
+- **Sales Orders** — WooCommerce → ERPNext (out of scope here)
+
+The connector supports **multiple WooCommerce servers** per ERPNext instance. A single ERPNext Item can be linked to several WooCommerce sites simultaneously, each tracked independently.
+
+---
+
+## 2. Architecture & Key Data Structures
+
+### 2.1 High-Level Component Map
+
+```
+hooks.py
+  ├── Item.on_update / after_insert  →  run_item_sync_from_hook()
+  ├── Item Price.on_update           →  update_item_price_for_woocommerce_item_from_hook()
+  ├── Scheduled Hourly               →  sync_woocommerce_products_modified_since()
+  └── Scheduled Daily                →  run_item_price_sync_in_background()
+
+tasks/sync_items.py
+  ├── run_item_sync()                 [orchestrator]
+  └── SynchroniseItem                [core sync class]
+       ├── get_corresponding_item_or_product()
+       ├── sync_wc_product_with_erpnext_item()  [direction decision]
+       ├── create_item()             [WC → ERPNext]
+       ├── update_item()             [WC → ERPNext]
+       ├── create_woocommerce_product()  [ERPNext → WC]
+       └── update_woocommerce_product()  [ERPNext → WC]
+
+tasks/sync_item_prices.py
+  ├── run_item_price_sync()           [orchestrator]
+  └── SynchroniseItemPrice           [core price sync class]
+       ├── get_erpnext_item_prices()
+       └── sync_items_with_woocommerce_products()
+
+woocommerce/woocommerce_api.py
+  └── WooCommerceResource            [virtual doctype base, wraps WC REST API]
+
+woocommerce/doctype/woocommerce_product/
+  └── WooCommerceProduct             [virtual doctype, /products endpoint]
+```
+
+### 2.2 ERPNextItemToSync Dataclass
+
+**File**: `tasks/sync_items.py`, lines 126–135
+
+```python
+@dataclass
+class ERPNextItemToSync:
+    item: Item
+    item_woocommerce_server_idx: int  # 1-based index into item.woocommerce_servers
+
+    @property
+    def item_woocommerce_server(self):
+        return self.item.woocommerce_servers[self.item_woocommerce_server_idx - 1]
+```
+
+This dataclass binds an ERPNext `Item` document to one specific entry in its `woocommerce_servers` child table, effectively creating a "Item + Server" pair as the unit of sync work.
+
+### 2.3 WooCommerce Product Virtual DocType
+
+`WooCommerceProduct` is a **Frappe virtual doctype** that does not have a database table. All CRUD operations are forwarded to the WooCommerce REST API:
+
+| Frappe Method | WC API Call |
+|---------------|-------------|
+| `db_insert()` | `POST /wp-json/wc/v3/products` |
+| `db_update()` | `PUT /wp-json/wc/v3/products/{id}` |
+| `load_from_db()` | `GET /wp-json/wc/v3/products/{id}` |
+| `get_list()` | `GET /wp-json/wc/v3/products` (paginated) |
+
+Variations use a sub-resource: `products/{parent_id}/variations/{id}`.
+
+### 2.4 Record Naming Convention
+
+WooCommerce records inside Frappe use the format:
+
+```
+{domain}~{woocommerce_resource_id}
+```
+
+Examples:
+- `mystore.woocommerce.com~42`
+- `shop.example.com~1001`
+
+The delimiter `~` is defined as `WC_RESOURCE_DELIMITER` in `woocommerce_api.py`. Helper functions:
+
+- `generate_woocommerce_record_name_from_domain_and_id()` (line 493)
+- `get_domain_and_id_from_woocommerce_record_name()` (line 611)
+- `parse_domain_from_url()` (line 604)
+
+---
+
+## 3. Item Sync — Trigger Points
+
+### 3.1 Document Hooks (Real-Time)
+
+Defined in `hooks.py` lines 127–135:
+
+```python
+doc_events = {
+    "Item": {
+        "on_update": "woocommerce_fusion.tasks.sync_items.run_item_sync_from_hook",
+        "after_insert": "woocommerce_fusion.tasks.sync_items.run_item_sync_from_hook",
+    }
+}
+```
+
+**`run_item_sync_from_hook()`** (lines 25–39):
+1. Checks `item.created_by_sync != True` — this flag prevents recursive syncs when items are created/updated by the sync itself.
+2. Shows a blue info alert to the user: "Syncing with WooCommerce..."
+3. Enqueues `clear_sync_hash_and_run_item_sync()` with `enqueue_after_commit=True` so the background job only starts after the current database transaction commits.
+
+**`clear_sync_hash_and_run_item_sync()`**:
+- Clears `woocommerce_last_sync_hash` on the `Item WooCommerce Server` child row.
+- Then calls `run_item_sync()`.
+- Clearing the hash forces the sync to re-evaluate, because the hash comparison (see Section 5) would otherwise consider the item "already synced."
+
+### 3.2 Scheduled Tasks
+
+Defined in `hooks.py` lines 147–154:
+
+```python
+scheduler_events = {
+    "hourly_long": [
+        "woocommerce_fusion.tasks.sync_items.sync_woocommerce_products_modified_since",
+    ],
+    "daily_long": [
+        "woocommerce_fusion.tasks.sync_items.run_item_price_sync_in_background",
+    ],
+}
+```
+
+- **Hourly Long**: Pulls all WooCommerce products modified since the last recorded sync date and enqueues per-product syncs.
+- **Daily Long**: Full price list sync for all items linked to WooCommerce servers.
+
+### 3.3 Manual / Programmatic Triggers
+
+Via ERPNext Item form (UI buttons, see Section 18):
+- "Sync this Item with WooCommerce" → calls `run_item_sync(item_code)`
+- "Sync this Item's Price to WooCommerce" → calls `run_item_price_sync(item_code)`
+- "Sync this Item's Stock Levels to WooCommerce" → calls `update_stock_levels_on_woocommerce_site(item_code)`
+
+---
+
+## 4. Item Sync — Core Logic: SynchroniseItem
+
+**File**: `tasks/sync_items.py`, lines 138–587
+
+### 4.1 Entry Point: `run_item_sync()`
+
+Lines 42–92. Accepts either:
+- `item_code` (str) + optional `item` doc — resolves to an ERPNext Item
+- `woocommerce_product_name` (str) + optional `woocommerce_product` doc — resolves to a WC product
+
+For each WooCommerce Server found on the item (iterating `item.woocommerce_servers`), it:
+1. Constructs an `ERPNextItemToSync` with the item and the server index.
+2. Creates a `SynchroniseItem` instance.
+3. Either calls `.run()` synchronously or enqueues it as a background job depending on the `enqueue` parameter.
+4. Returns `(Item, WooCommerceProduct)`.
+
+### 4.2 SynchroniseItem.run() — Main Workflow
+
+Lines 154–172:
+
+```python
+def run(self):
+    try:
+        self.get_corresponding_item_or_product()
+        self.sync_wc_product_with_erpnext_item()
+    except Exception:
+        error_message = frappe.get_traceback()
+        # Append item and product data to error message
+        frappe.log_error("WooCommerce Error", error_message)
+```
+
+### 4.3 `get_corresponding_item_or_product()`
+
+Lines 174–230. Fills in the missing side of the (item, product) pair:
+
+**Case A — Have item, need product:**
+- Reads `item_woocommerce_server.woocommerce_id`.
+- If not set, attempts to find a WC product by SKU (product's `sku` field matches `item.item_code`).
+- If found by SKU, immediately writes the `woocommerce_id` back to the child table.
+- If not found at all, `self.woocommerce_product` stays `None` → triggers product creation.
+
+**Case B — Have product, need item:**
+- Queries `Item WooCommerce Server` child table for a row where `woocommerce_id` matches the product's ID.
+- If not found, tries matching by item_code against the product's SKU.
+- If still not found, `self.item` stays `None` → triggers item creation.
+
+---
+
+## 5. Sync Direction & Conflict Resolution
+
+### 5.1 Decision Logic
+
+`sync_wc_product_with_erpnext_item()` — lines 232–255:
+
+```
+IF self.item is None:
+    → create_item()          (WooCommerce → ERPNext)
+
+ELIF self.woocommerce_product is None:
+    → create_woocommerce_product()  (ERPNext → WooCommerce)
+
+ELSE:  # Both exist
+    woocommerce_date_modified = woocommerce_product.woocommerce_date_modified
+    last_sync_hash = item.item_woocommerce_server.woocommerce_last_sync_hash
+
+    IF woocommerce_date_modified == last_sync_hash:
+        # Nothing changed on WooCommerce side since last sync
+        # But ERPNext side might have changed → handled by hook trigger
+
+    ELIF woocommerce_date_modified > item.modified:
+        → update_item()      (WooCommerce → ERPNext: WC is newer)
+
+    ELIF woocommerce_date_modified < item.modified:
+        → update_woocommerce_product()  (ERPNext → WooCommerce: ERPNext is newer)
+```
+
+### 5.2 The Sync Hash Mechanism
+
+The `woocommerce_last_sync_hash` field on the `Item WooCommerce Server` child table stores the **WooCommerce product's `date_modified` timestamp** at the moment of last successful sync.
+
+Its purpose is two-fold:
+1. **Loop prevention**: After syncing ERPNext → WooCommerce, WooCommerce returns a new `date_modified`. That value is stored as the hash. On the next hourly scan, this product would match the `date_time_from` filter — but the hash comparison immediately identifies that this is the same state that was just synced, skipping redundant work.
+2. **Change detection**: If `date_modified != last_sync_hash`, something changed in WooCommerce since last sync. Combined with timestamp comparison, the system decides which system to trust.
+
+**How it's updated** — `set_sync_hash()` (lines 571–577):
+```python
+frappe.db.set_value(
+    "Item WooCommerce Server",
+    child_row_name,
+    "woocommerce_last_sync_hash",
+    woocommerce_date_modified,
+    update_modified=False  # Doesn't bump Item.modified, avoids re-triggering hook
+)
+```
+
+**When it's cleared**: Before a hook-triggered sync (`clear_sync_hash_and_run_item_sync()`). This forces the comparison to detect a difference, ensuring the hook-triggered change propagates.
+
+### 5.3 Conflict Resolution Summary
+
+| Scenario | Winner | Action |
+|----------|--------|--------|
+| Only product exists | WooCommerce | Create ERPNext Item |
+| Only item exists (with WC server entry) | ERPNext | Create WooCommerce Product |
+| Both exist, WC newer | WooCommerce | Update ERPNext Item |
+| Both exist, ERPNext newer | ERPNext | Update WooCommerce Product |
+| Both exist, hash matches WC date | No change needed | Skip |
+
+There is **no manual priority override** — it is strictly last-write-wins based on timestamps.
+
+---
+
+## 6. ERPNext → WooCommerce: Create & Update
+
+### 6.1 Create WooCommerce Product
+
+`create_woocommerce_product()` — lines 303–374
+
+**When triggered**: Item has a `woocommerce_servers` entry with a configured server but no `woocommerce_id`.
+
+**Steps**:
+1. Create a new `WooCommerceProduct` document in-memory.
+2. Set `woocommerce_server` to the server name.
+3. Set `woocommerce_name` = `item.item_name`.
+4. Determine product type:
+   - `"variable"` if `item.has_variants == 1`
+   - `"variation"` if `item.variant_of` is set
+   - `"simple"` otherwise
+5. If `type == "variable"`: Build `attributes` JSON from `Item Attribute` docs and set it on the product.
+6. If `type == "variation"`: Find parent's `woocommerce_id` from the parent item's `woocommerce_servers` table and set `parent_id`.
+7. If `WooCommerce Server.enable_price_list_sync`: Set `regular_price` via `get_item_price_rate()`.
+8. Apply custom field mappings via `set_product_fields()`.
+9. Call `woocommerce_product.insert()` → `db_insert()` → `POST /products`.
+10. WooCommerce returns the new product ID and `date_modified`; these are written back to `Item WooCommerce Server.woocommerce_id`.
+11. Call `set_sync_hash()` with the returned `date_modified`.
+
+### 6.2 Update WooCommerce Product
+
+`update_woocommerce_product()` — lines 282–301
+
+**When triggered**: Both item and product exist, and ERPNext item is newer.
+
+**Steps**:
+1. Compare `item.item_name` with `woocommerce_product.woocommerce_name`; update if different.
+2. If `WooCommerce Server.enable_image_sync` and item has an image URL: update `woocommerce_product.images`.
+3. Apply custom field mappings via `set_product_fields()`.
+4. If any field changed (`product_dirty == True`): call `woocommerce_product.save()` → `db_update()` → `PUT /products/{id}`.
+5. Call `set_sync_hash()`.
+
+### 6.3 `set_product_fields()` — Field Mapping ERPNext → WooCommerce
+
+Lines 510–564.
+
+For each entry in `WooCommerce Server.item_field_map`:
+1. Read `erpnext_field_name` value from `self.item.item`.
+2. Deserialize WooCommerce product fields that are stored as JSON strings (e.g., `meta_data`, `attributes`).
+3. Use `jsonpath_ng.ext.parse(woocommerce_field_name).update(wc_product_dict, value)` to write the value into the correct nested location.
+4. Re-serialize after updates.
+5. Track if anything actually changed (`product_dirty` flag).
+
+**Strict validation for updates**: If the JSONPath expression targets a path that doesn't exist in the product dict, an error is raised. For new product creation, missing paths are allowed (the field just won't be set).
+
+---
+
+## 7. WooCommerce → ERPNext: Create & Update
+
+### 7.1 Create ERPNext Item
+
+`create_item()` — lines 376–440
+
+**When triggered**: A WooCommerce product has no matching ERPNext Item.
+
+**Item Code Determination** based on `WooCommerce Server.name_by`:
+- `"Product SKU"`: Uses `woocommerce_product.sku` as `item_code`.
+- `"WooCommerce ID"` (default): Uses `woocommerce_product.woocommerce_id` (the numeric WC product ID).
+
+**Key fields set**:
+
+| Item Field | Source |
+|------------|--------|
+| `item_code` | SKU or WC ID (per `name_by` setting) |
+| `item_name` | `woocommerce_product.woocommerce_name` |
+| `item_group` | `WooCommerce Server.item_group` |
+| `stock_uom` | `WooCommerce Server.uom` (fallback: `"Nos"`) |
+| `image` | First image URL from WC product (if `enable_image_sync`) |
+| `variant_of` | Parent item's `item_code` (for variations) |
+| Custom fields | Via `set_item_fields()` field mappings |
+
+**Variant handling**:
+- For **variable** products (`type == "variable"`): Creates `Item Attribute` docs for each product attribute.
+- For **variation** products (`type == "variation"`): Sets `variant_of` to the parent item's code; also adds attribute values from the variation's attributes.
+
+**Insert flags**:
+```python
+item.flags.ignore_mandatory = True   # Skip mandatory field validation
+item.flags.created_by_sync = True    # Prevent on_update hook from re-triggering sync
+item.insert()
+```
+
+After insert, adds a row to `item.woocommerce_servers` with `woocommerce_id` and server info, then calls `set_sync_hash()`.
+
+### 7.2 Update ERPNext Item
+
+`update_item()` — lines 257–280
+
+**When triggered**: Both exist, WooCommerce product has a more recent `date_modified` than `item.modified`.
+
+**Steps**:
+1. Update `item.item_name` from `woocommerce_product.woocommerce_name` if different.
+2. Update `item.image` from first WC product image if `enable_image_sync`.
+3. Apply custom field mappings via `set_item_fields()`.
+4. If any change detected (`item_dirty == True`):
+   - Set `item.flags.created_by_sync = True` (prevents recursive hook).
+   - Call `item.save()`.
+5. Call `set_sync_hash()`.
+
+### 7.3 `set_item_fields()` — Field Mapping WooCommerce → ERPNext
+
+Lines 483–508.
+
+For each entry in `WooCommerce Server.item_field_map`:
+1. Deserialize WooCommerce product JSON fields.
+2. Use `jsonpath_ng.ext.parse(woocommerce_field_name).find(wc_product_dict)` to extract the value.
+3. Assign the extracted value to `item.{erpnext_field_name}`.
+4. Set `item_dirty = True` if value changed.
+
+---
+
+## 8. Scheduled (Hourly) Item Sync
+
+### 8.1 `sync_woocommerce_products_modified_since()`
+
+Lines 95–123.
+
+**Flow**:
+1. Read `WooCommerce Integration Settings.wc_last_sync_date_items` (the last time this ran).
+2. Call `get_list_of_wc_products(date_time_from=last_sync_date)`.
+3. For each product returned:
+   - Enqueue `run_item_sync(woocommerce_product=product, enqueue=True)`.
+4. Update `wc_last_sync_date_items = frappe.utils.now()`.
+
+On the **first run** (no `wc_last_sync_date_items`), fetches all products. Subsequent runs fetch only those modified since the last sync, making it efficient.
+
+### 8.2 `get_list_of_wc_products()`
+
+Lines 590–633.
+
+- Paginates: fetches 100 products per page, continues until no more pages.
+- Handles **multiple servers**: iterates all enabled `WooCommerce Server` docs.
+- Supports an optional `item` parameter — if provided, fetches only the specific product linked to that item (for hook-triggered syncs).
+- Builds product names as `{domain}~{id}` for each returned product.
+- Includes product **variations** (fetched separately per variable product).
+
+---
+
+## 9. Item Price Sync — Architecture
+
+### 9.1 Design Philosophy
+
+Item price sync is **one-directional**: ERPNext → WooCommerce only.
+
+- ERPNext is the **source of truth** for prices.
+- The system reads from a configured `Price List` and pushes `regular_price` to WooCommerce.
+- There is no mechanism to pull WooCommerce prices back to ERPNext.
+
+### 9.2 Trigger Points
+
+**Hook-based** (hooks.py line 127):
+```python
+"Item Price": {
+    "on_update": "woocommerce_fusion.tasks.sync_item_prices.update_item_price_for_woocommerce_item_from_hook"
+}
+```
+
+`update_item_price_for_woocommerce_item_from_hook()`:
+- Checks if the changed Item Price belongs to a WooCommerce-linked item on the relevant price list.
+- Enqueues `run_item_price_sync(item_code, item_price_doc)` with `enqueue_after_commit=True`.
+
+**Scheduled** (hooks.py line 153):
+```python
+"daily_long": ["woocommerce_fusion.tasks.sync_item_prices.run_item_price_sync_in_background"]
+```
+
+`run_item_price_sync_in_background()`:
+- Enqueues `run_item_price_sync()` with `queue="long"` and `timeout=3600`.
+- No item filter — syncs all items across all servers.
+
+---
+
+## 10. Item Price Sync — Core Logic: SynchroniseItemPrice
+
+**File**: `tasks/sync_item_prices.py`, lines 40–134
+
+### 10.1 `run_item_price_sync()` — Entry Point
+
+Lines 34–37:
+```python
+def run_item_price_sync(item_code=None, item_price_doc=None):
+    SynchroniseItemPrice(item_code=item_code, item_price_doc=item_price_doc).run()
+```
+
+### 10.2 `SynchroniseItemPrice.run()`
+
+Lines 60–67:
+
+```python
+def run(self):
+    for server in self.servers:  # All enabled WooCommerce Servers
+        self.wc_server = server
+        self.get_erpnext_item_prices()
+        self.sync_items_with_woocommerce_products()
+```
+
+### 10.3 `get_erpnext_item_prices()`
+
+Lines 69–96. Runs the following SQL join:
+
+```sql
+SELECT
+    Item Price.name,
+    Item Price.item_code,
+    Item Price.price_list_rate,
+    Item WooCommerce Server.woocommerce_server,
+    Item WooCommerce Server.woocommerce_id
+FROM `tabItem Price`
+JOIN `tabItem WooCommerce Server`
+    ON Item Price.item_code = Item WooCommerce Server.parent
+    AND Item WooCommerce Server.parenttype = 'Item'
+JOIN `tabItem`
+    ON Item.name = Item WooCommerce Server.parent
+WHERE
+    Item Price.price_list = {server.price_list}
+    AND Item WooCommerce Server.woocommerce_server = {server.name}
+    AND Item.disabled = 0
+    AND Item WooCommerce Server.woocommerce_id IS NOT NULL
+    AND Item WooCommerce Server.enabled = 1
+    [AND Item Price.item_code = {item_code}]  -- if item_code provided
+```
+
+Results are stored in `self.item_price_list`.
+
+### 10.4 `sync_items_with_woocommerce_products()`
+
+Lines 98–133.
+
+For each item price record:
+1. Construct WooCommerce product name: `{domain}~{woocommerce_id}`.
+2. Load WooCommerce Product via `frappe.get_doc("WooCommerce Product", name)`.
+3. Compare prices:
+   ```python
+   wc_price = float(wc_product.regular_price or 0)
+   erp_price = float(item_price.price_list_rate or 0)
+   if wc_price != erp_price:
+       wc_product.regular_price = erp_price
+       wc_product.save()  # PUT /products/{id}
+   ```
+4. Sleep `WooCommerce Server.price_list_delay_per_item` seconds (default: 2) between requests.
+5. Exceptions per product are caught, logged, and the loop continues.
+
+### 10.5 Price on Product Creation
+
+`get_item_price_rate()` — lines 636–655:
+
+When **creating** a new WooCommerce product from an ERPNext item, if `enable_price_list_sync` is enabled:
+- Queries Item Price for:
+  - `item_code = item.name`
+  - `price_list = server.price_list`
+  - Valid: no `valid_upto` OR `valid_upto > now()`
+- Returns `price_list_rate` of the first valid price.
+- Sets `woocommerce_product.regular_price = rate` before the initial `POST`.
+
+---
+
+## 11. Field Mapping & JSONPath Integration
+
+### 11.1 Configuration
+
+Field mappings are stored in a child table `WooCommerce Server Item Field` on each `WooCommerce Server` document (field name: `item_field_map`).
+
+Each row has:
+| Field | Purpose |
+|-------|---------|
+| `erpnext_field_name` | Name of the ERPNext Item field |
+| `woocommerce_field_name` | JSONPath expression pointing to a location in the WooCommerce product JSON |
+
+### 11.2 JSONPath Expression Examples
+
+| JSONPath | Targets |
+|----------|---------|
+| `$.short_description` | Top-level WC field |
+| `$.meta_data[?(@.key=='_custom_field')].value` | Value inside meta_data array filtered by key |
+| `$.attributes[0].options[0]` | First option of first attribute |
+
+The library used is `jsonpath-ng.ext` which supports extended JSONPath syntax including filter expressions (`?(@.key==...)`).
+
+### 11.3 Validation
+
+`WooCommerceServer.validate_item_map()` (server doctype's `validate()` hook):
+- Parses each JSONPath expression using `jsonpath_ng.ext.parse()`.
+- Raises a `frappe.ValidationError` if any expression is syntactically invalid.
+- Explicitly **disallows** the expressions `"attributes"` and `"images"` — these are handled by built-in sync logic, not field mapping.
+
+### 11.4 Serialization / Deserialization
+
+WooCommerce product fields like `attributes`, `images`, `categories`, and `meta_data` are arrays/objects in the WC API but stored as JSON strings in Frappe's virtual doctype layer.
+
+Before JSONPath operations, `deserialize_attributes_of_type_dict_or_list()` converts JSON strings back to Python dicts/lists. After updates, `serialize_attributes_of_type_dict_or_list()` converts them back to strings for storage and API transmission.
+
+This means JSONPath queries always operate on **native Python data structures**, not raw strings.
+
+---
+
+## 12. WooCommerce API Layer
+
+### 12.1 WooCommerceResource Base Class
+
+**File**: `woocommerce/woocommerce_api.py`
+
+All WooCommerce virtual doctypes inherit from this. Key methods:
+
+**`load_from_db()`**: Parses the document name (`{domain}~{id}`), extracts the domain to find the correct `WooCommerce Server` config, calls `GET /products/{id}`, and populates `self` fields from the response via `pre_init_document()`.
+
+**`db_insert()`**: Serializes the document, calls `POST /products`, captures the returned `id` and `date_modified`, and stores them back on the document.
+
+**`db_update()`**: Serializes only the **changed fields** (tracked via Frappe's dirty field mechanism), calls `PUT /products/{id}`.
+
+**`get_list_of_records()`**: Handles pagination — loops through pages of 100 records, collecting all results. Supports date filters via `modified_after` parameter.
+
+**`pre_init_document()`**: Transforms the WooCommerce API response format into Frappe's expected format:
+- Maps `id` → `woocommerce_id`
+- Maps `name` (WC title) → `woocommerce_name`
+- Serializes nested objects to JSON strings for storage
+
+### 12.2 Request Logging via APIWithRequestLogging
+
+**File**: `tasks/utils.py`
+
+When `WooCommerce Server.enable_woocommerce_request_logs` is enabled:
+
+1. `APIWithRequestLogging` wraps the `woocommerce` Python library's internal `_API__request()` method.
+2. Every API call is intercepted: method, URL, params, request body, response body, status code, and elapsed time are captured.
+3. An async background job logs this to a `WooCommerce Request Log` document.
+4. Logs are automatically purged after 7 days (`hooks.py`, line 260–262).
+
+### 12.3 Authentication
+
+Uses OAuth 1.0a via WooCommerce's `api_consumer_key` and `api_consumer_secret`. These are stored on the `WooCommerce Server` document and passed to the `woocommerce` Python library on each instantiation.
+
+---
+
+## 13. Variant / Attribute Handling
+
+### 13.1 ERPNext Item Types
+
+| ERPNext Field | Meaning | WC Product Type |
+|---------------|---------|-----------------|
+| `has_variants = 0`, `variant_of = None` | Simple item | `"simple"` |
+| `has_variants = 1` | Item template with variants | `"variable"` |
+| `variant_of = {parent_code}` | Specific variant | `"variation"` |
+
+### 13.2 Creating Variable Products from ERPNext Templates
+
+When `item.has_variants == 1`:
+1. Reads `Item Attribute` records linked to the item.
+2. Builds an `attributes` JSON array: each attribute has a name and its possible values.
+3. Sets `woocommerce_product.attributes = json.dumps(attributes_list)`.
+4. WooCommerce receives this as `type: "variable"` with `attributes` array — WooCommerce then allows creating variations.
+
+### 13.3 Creating Variations from ERPNext Variants
+
+When `item.variant_of` is set:
+1. Fetches the parent item's `woocommerce_id` from its `woocommerce_servers` child table.
+2. Sets `woocommerce_product.parent_id = parent_woocommerce_id`.
+3. Reads the variant's specific attribute values (e.g., `Color: Red`, `Size: Large`).
+4. Sets `woocommerce_product.attributes` with the specific selected values.
+5. Product is created via the variations sub-endpoint: `POST /products/{parent_id}/variations`.
+
+### 13.4 Creating ERPNext Attributes from WooCommerce Variable Products
+
+When `woocommerce_product.type == "variable"`:
+- Iterates `woocommerce_product.attributes` (deserialized from JSON).
+- For each attribute, ensures an `Item Attribute` doc exists in ERPNext (creates if missing).
+- Adds attribute to the item template's `attributes` child table.
+
+For `type == "variation"`:
+- Sets `item.variant_of` to parent item code.
+- Adds the specific attribute values to the variant item.
+
+---
+
+## 14. Stock Level Sync (Related Context)
+
+While not the primary focus of this research, stock sync is tightly integrated with item sync architecture.
+
+### 14.1 Triggers
+
+Document hooks on submit/cancel:
+- `Stock Entry`, `Stock Reconciliation`, `Sales Invoice` (if `update_stock == 1`), `Delivery Note`
+
+All call `update_stock_levels_for_woocommerce_item()` → enqueues `update_stock_levels_on_woocommerce_site(item_code)`.
+
+Scheduled: **Daily Long** runs `update_stock_levels_for_all_enabled_items_in_background()`.
+
+### 14.2 Quantity Calculation
+
+For each WooCommerce Server linked to the item:
+1. Query all `Bin` records for the item.
+2. Filter bins to those in `WooCommerce Server.warehouses` (Table MultiSelect).
+3. Sum `actual_qty` across matching bins.
+4. If `WooCommerce Server.subtract_reserved_stock == 1`: subtract `reserved_qty`.
+5. Floor to integer (WooCommerce requires whole number stock counts).
+6. PUT `stock_quantity` to the product.
+
+---
+
+## 15. Configuration Reference
+
+### 15.1 WooCommerce Server Settings
+
+**DocType**: `WooCommerce Server` (multi-document, one per WooCommerce site)
+
+#### Connection
+| Field | Type | Description |
+|-------|------|-------------|
+| `enable_sync` | Check | Master on/off switch — required for any sync |
+| `woocommerce_server_url` | Data | Full URL of the WooCommerce site |
+| `api_consumer_key` | Data | OAuth consumer key |
+| `api_consumer_secret` | Password | OAuth consumer secret |
+| `secret` | Data | Webhook verification hash |
+
+#### Item Sync
+| Field | Type | Description |
+|-------|------|-------------|
+| `name_by` | Select | How to set `item_code`: "WooCommerce ID" or "Product SKU" |
+| `item_group` | Link | Default Item Group for items created from WooCommerce |
+| `uom` | Link | Default Unit of Measure for new items |
+| `enable_image_sync` | Check | Sync WC product's first image to `Item.image` |
+| `item_field_map` | Table | Custom field mappings (JSONPath based) |
+
+#### Price List
+| Field | Type | Description |
+|-------|------|-------------|
+| `enable_price_list_sync` | Check | Enable price syncing |
+| `price_list` | Link | ERPNext Price List to sync from |
+| `price_list_delay_per_item` | Int | Seconds to sleep between price updates (default: 2) |
+
+#### Stock
+| Field | Type | Description |
+|-------|------|-------------|
+| `enable_stock_level_synchronisation` | Check | Enable stock sync |
+| `warehouses` | Table | Warehouses included in stock calculations |
+| `subtract_reserved_stock` | Check | Subtract `reserved_qty` from stock counts |
+
+#### Orders
+| Field | Type | Description |
+|-------|------|-------------|
+| `company` | Link | ERPNext Company for auto-created sales orders |
+| `warehouse` | Link | Default warehouse for sales orders |
+| `creation_user` | Link | User assigned as creator of auto-created docs |
+
+#### Logging
+| Field | Type | Description |
+|-------|------|-------------|
+| `enable_woocommerce_request_logs` | Check | Log all WC API calls to `WooCommerce Request Log` |
+
+### 15.2 WooCommerce Integration Settings
+
+**DocType**: `WooCommerce Integration Settings` (Single)
+
+| Field | Description |
+|-------|-------------|
+| `wc_last_sync_date_items` | Timestamp of last hourly item sync run |
+| `wc_last_sync_date` | Timestamp of last order sync run |
+| `minimum_creation_date` | Orders created before this date are ignored |
+
+### 15.3 Item WooCommerce Server (Child Table on Item)
+
+**DocType**: `Item WooCommerce Server`
+
+| Field | Description |
+|-------|-------------|
+| `enabled` | Whether sync is active for this server |
+| `woocommerce_server` | Link to `WooCommerce Server` doc |
+| `woocommerce_id` | Numeric product ID on WooCommerce |
+| `woocommerce_last_sync_hash` | Stores WC `date_modified` at last sync (read-only) |
+| `view_product` | Button: navigates to WooCommerce Product form |
+
+---
+
+## 16. Custom Fields Added to Standard DocTypes
+
+Defined in `fixtures/custom_field.json`:
+
+**On Item**:
+- `woocommerce_servers` — Table field (links to `Item WooCommerce Server` child table)
+- `custom_woocommerce_tab` — Tab Break creating a "WooCommerce" tab in the Item form
+
+**On Sales Order** (for order sync, not item sync):
+- `woocommerce_id`, `woocommerce_server`, `woocommerce_status`
+- `woocommerce_payment_method`, `woocommerce_payment_entry`
+
+---
+
+## 17. Error Handling & Logging
+
+### 17.1 Per-Sync Error Handling
+
+In `SynchroniseItem.run()` (lines 161–172):
+```python
+except Exception:
+    error_message = (
+        frappe.get_traceback()
+        + "\nItem data: " + str(self.item)
+        + "\nProduct data: " + str(self.woocommerce_product)
+    )
+    frappe.log_error("WooCommerce Error", error_message)
+```
+
+The full traceback plus both the item and product data objects are logged. This helps diagnose partial state issues.
+
+### 17.2 Per-Item Price Error Handling
+
+In `sync_items_with_woocommerce_products()` (lines 130–132):
+```python
+except Exception:
+    frappe.log_error("WooCommerce Price Sync Error", frappe.get_traceback())
+    # Loop continues to next product
+```
+
+Failures on individual products do **not** halt the batch — the sync continues with the next product.
+
+### 17.3 SyncDisabledError
+
+**File**: `exceptions.py`
+
+A custom exception `SyncDisabledError` is raised when:
+- A `WooCommerce Server` has `enable_sync == 0`.
+- The item's specific server entry has `enabled == 0`.
+
+This is caught in the sync flow and treated as a non-error early exit (the item is silently skipped).
+
+### 17.4 WooCommerce Request Logs
+
+**DocType**: `WooCommerce Request Log`
+
+Stores per-API-call records when logging is enabled:
+- Request: method, endpoint, params, body
+- Response: status code, body
+- Metadata: server name, timestamp, elapsed time, calling code traceback
+- Auto-deleted after 7 days (`hooks.py` line 260–262).
+
+---
+
+## 18. UI Integration
+
+### 18.1 Custom Buttons on Item Form
+
+**File**: `public/js/stock/item.js`
+
+Three custom buttons are added to the Item form in the "WooCommerce" section:
+
+1. **"Sync this Item with WooCommerce"**
+   - Freezes the UI, calls `run_item_sync(item_code)` via `frappe.call`.
+   - Shows success alert and reloads doc; shows error alert on failure.
+
+2. **"Sync this Item's Price to WooCommerce"**
+   - Calls `run_item_price_sync(item_code)` via `frappe.call`.
+
+3. **"Sync this Item's Stock Levels to WooCommerce"**
+   - Calls `update_stock_levels_on_woocommerce_site(item_code)` via `frappe.call`.
+
+### 18.2 View Product Button in Child Table
+
+In the `Item WooCommerce Server` child table on the Item form, a "View Product" button navigates to:
+```
+/app/woocommerce-product/{server}~{woocommerce_id}
+```
+
+This opens the WooCommerce Product virtual doctype form where the current WC state can be viewed.
+
+---
+
+## 19. End-to-End Sync Flow Diagrams
+
+### 19.1 New WooCommerce Product → Create ERPNext Item
+
+```
+WC Product created on WooCommerce site
+        ↓
+[Hourly scheduler fires]
+sync_woocommerce_products_modified_since()
+        ↓
+get_list_of_wc_products(date_time_from=last_sync_date)
+  [paginates /products?after={date}, 100/page]
+        ↓
+For each WC product returned:
+  enqueue run_item_sync(woocommerce_product=wc_product)
+        ↓
+SynchroniseItem.run()
+  get_corresponding_item_or_product()
+    → No matching Item found → self.item = None
+        ↓
+  sync_wc_product_with_erpnext_item()
+    → self.item is None → create_item()
+        ↓
+  create_item()
+    - item_code = wc_product.sku  OR  wc_product.id  (per name_by)
+    - item_group = server.item_group
+    - uom = server.uom
+    - image = wc_product.images[0] (if enable_image_sync)
+    - Apply set_item_fields() custom mappings
+    - item.insert(ignore_mandatory=True, created_by_sync=True)
+        ↓
+  set_sync_hash(woocommerce_date_modified)
+        ↓
+Update wc_last_sync_date_items = now()
+```
+
+### 19.2 ERPNext Item Modified → Update WooCommerce Product
+
+```
+User edits ERPNext Item (e.g., changes item_name)
+        ↓
+Item.on_update hook fires
+  run_item_sync_from_hook()
+    - Check: created_by_sync != True ✓
+    - Show alert: "Syncing with WooCommerce..."
+    - enqueue_after_commit: clear_sync_hash_and_run_item_sync()
+        ↓
+[Transaction commits]
+        ↓
+clear_sync_hash_and_run_item_sync()
+  - Clear woocommerce_last_sync_hash on Item WC Server row
+        ↓
+run_item_sync(item_code)
+  SynchroniseItem.run()
+  get_corresponding_item_or_product()
+    → Load WC product via woocommerce_id
+        ↓
+  sync_wc_product_with_erpnext_item()
+    - woocommerce_date_modified ≠ last_sync_hash (hash was cleared) ✓
+    - item.modified > woocommerce_date_modified
+    → update_woocommerce_product()
+        ↓
+  update_woocommerce_product()
+    - Compare woocommerce_name vs item_name
+    - Apply set_product_fields() custom mappings
+    - If changed: woocommerce_product.save()
+        → PUT /products/{id} with changed fields only
+        ↓
+  set_sync_hash(new woocommerce_date_modified from response)
+```
+
+### 19.3 WooCommerce Product Modified → Update ERPNext Item
+
+```
+Product updated on WooCommerce
+        ↓
+[Hourly scheduler fires]
+sync_woocommerce_products_modified_since()
+  → Fetches products modified since last_sync_date
+  → Finds the modified product
+        ↓
+enqueue run_item_sync(woocommerce_product=modified_product)
+        ↓
+SynchroniseItem.run()
+  get_corresponding_item_or_product()
+    → Finds matching ERPNext Item via woocommerce_id
+        ↓
+  sync_wc_product_with_erpnext_item()
+    - woocommerce_date_modified ≠ last_sync_hash ✓
+    - woocommerce_date_modified > item.modified
+    → update_item()
+        ↓
+  update_item()
+    - item_name ← woocommerce_product.woocommerce_name
+    - image ← wc_product.images[0] (if enable_image_sync)
+    - Apply set_item_fields() custom mappings
+    - item.flags.created_by_sync = True  [prevents hook re-trigger]
+    - item.save()
+        ↓
+  set_sync_hash(woocommerce_date_modified)
+```
+
+### 19.4 Item Price Update → Sync to WooCommerce
+
+```
+User updates Item Price in ERPNext
+        ↓
+Item Price.on_update hook fires
+  update_item_price_for_woocommerce_item_from_hook()
+    - Check: item linked to WC server ✓
+    - Check: price_list matches server.price_list ✓
+    - enqueue_after_commit: run_item_price_sync(item_code)
+        ↓
+[Transaction commits]
+        ↓
+SynchroniseItemPrice(item_code=item_code).run()
+  For each WooCommerce Server:
+    get_erpnext_item_prices()
+      [JOIN query: Item Price + Item WC Server + Item]
+        ↓
+    sync_items_with_woocommerce_products()
+      For each item_price:
+        - Load WC product
+        - float(wc_product.regular_price) vs float(price_list_rate)
+        - If different:
+            wc_product.regular_price = price_list_rate
+            wc_product.save()  → PUT /products/{id}
+        - Sleep price_list_delay_per_item seconds
+```
+
+---
+
+## 20. Key Gotchas & Implementation Nuances
+
+### 20.1 The `created_by_sync` Flag
+
+This flag on `item.flags` (transient, not persisted) is **critical** for preventing infinite sync loops. When the sync system modifies an ERPNext item, it sets this flag before `item.save()`. The `on_update` hook checks for it and bails out early, preventing the save from triggering another round of sync.
+
+**Risk**: If the flag is not set correctly (e.g., due to a bug or direct `frappe.db` manipulation), infinite loops can occur.
+
+### 20.2 Sync Hash Clearing
+
+The sync hash is cleared by `clear_sync_hash_and_run_item_sync()` before each hook-triggered sync. This is necessary because:
+- Without clearing, the comparison `woocommerce_date_modified == last_sync_hash` might short-circuit the sync.
+- The ERPNext item was just modified, so we **want** to push changes to WooCommerce.
+- Clearing the hash forces the `≠` check to pass and proceeds to the timestamp comparison.
+
+### 20.3 Timestamp Comparison Precision
+
+The sync direction decision (`WC newer` vs `ERPNext newer`) is based on comparing:
+- `woocommerce_product.woocommerce_date_modified` (string from WC API, e.g., `"2024-01-15T10:30:00"`)
+- `item.modified` (Frappe datetime)
+
+This string comparison works because ISO 8601 timestamps sort lexicographically. However, **timezone differences** could potentially cause incorrect comparisons if the ERPNext server and WooCommerce server are in different timezones.
+
+### 20.4 Price List Delay
+
+The `price_list_delay_per_item` setting (default: 2 seconds) exists to avoid hitting WooCommerce API rate limits during bulk price syncs. For stores with thousands of products, the daily price sync can take a long time. A 2-second delay × 1000 products = ~33 minutes, which fits within the 3600-second (1 hour) timeout.
+
+### 20.5 `db_update()` Sends Only Changed Fields
+
+`WooCommerceResource.db_update()` leverages Frappe's built-in dirty field tracking to only send fields that actually changed in the PUT request. This is important because sending unchanged fields (especially complex ones like `attributes`) to WooCommerce can cause unintended side effects.
+
+### 20.6 Multi-Server Independence
+
+Each row in `item.woocommerce_servers` is processed independently. An item synced to Server A and Server B will have separate `woocommerce_id`, `woocommerce_last_sync_hash`, and `enabled` flags for each. A sync failure on one server does not affect the other.
+
+### 20.7 Product Variations and `parent_id`
+
+For variations, the WooCommerce API uses a different endpoint structure:
+```
+/products/{parent_id}/variations/{variation_id}
+```
+
+The `parent_id` must be determined by looking up the parent template item's `woocommerce_id`. If the parent has not yet been synced to WooCommerce (no `woocommerce_id`), variation creation will fail.
+
+### 20.8 Images: First Image Only
+
+Only the **first** image in the WooCommerce product's `images` array is synced to `Item.image`. Multiple images on a WooCommerce product do not map to ERPNext's single `image` field. When pushing from ERPNext to WooCommerce, only `Item.image` is synced (as a single image).
+
+### 20.9 JSONPath Filter Expressions Require Deserialization
+
+Because WooCommerce product fields like `meta_data` are stored as JSON strings in the virtual doctype, JSONPath filter expressions (e.g., `$.meta_data[?(@.key=='my_key')].value`) will only work correctly if the deserialization step runs first. The sync code always deserializes before JSONPath operations, but custom code that bypasses the sync layer would need to handle this manually.
+
+### 20.10 Price Sync Does Not Read from WooCommerce
+
+The `SynchroniseItemPrice` class never reads WooCommerce product prices to compare them before pushing. It relies entirely on the ERPNext Item Price data and pushes regardless of what's currently in WooCommerce. The only comparison is done at push time (loaded product vs. ERPNext rate) to avoid unnecessary API calls.
+
+### 20.11 Hourly Sync Updates `wc_last_sync_date_items` Even on Partial Failure
+
+`sync_woocommerce_products_modified_since()` updates `wc_last_sync_date_items` after enqueuing all jobs, not after they all complete. Individual job failures (logged via Frappe Error Log) do not roll back this timestamp. Products from a failed sync run won't be re-fetched unless they are modified again in WooCommerce.
+
+---
+
+## 21. File Location Reference
+
+| Component | File Path |
+|-----------|-----------|
+| **Item Sync — Main Logic** | `woocommerce_fusion/tasks/sync_items.py` |
+| **Item Price Sync** | `woocommerce_fusion/tasks/sync_item_prices.py` |
+| **Stock Update** | `woocommerce_fusion/tasks/stock_update.py` |
+| **WooCommerce API Base Class** | `woocommerce_fusion/woocommerce/woocommerce_api.py` |
+| **WooCommerce Product Virtual DocType** | `woocommerce_fusion/woocommerce/doctype/woocommerce_product/` |
+| **Item WooCommerce Server DocType** | `woocommerce_fusion/woocommerce/doctype/item_woocommerce_server/` |
+| **WooCommerce Server DocType** | `woocommerce_fusion/woocommerce/doctype/woocommerce_server/` |
+| **WooCommerce Integration Settings** | `woocommerce_fusion/woocommerce/doctype/woocommerce_integration_settings/` |
+| **Hooks & Scheduling** | `woocommerce_fusion/hooks.py` |
+| **Custom Fields Fixtures** | `woocommerce_fusion/fixtures/custom_field.json` |
+| **Item Form UI Buttons** | `woocommerce_fusion/public/js/stock/item.js` |
+| **API Request Logging Wrapper** | `woocommerce_fusion/tasks/utils.py` |
+| **Custom Exceptions** | `woocommerce_fusion/exceptions.py` |
+
+---
+
+*Research compiled from source code analysis of woocommerce_fusion codebase. All line numbers reference the state of the code at the time of analysis.*

--- a/woocommerce_fusion/hooks.py
+++ b/woocommerce_fusion/hooks.py
@@ -152,6 +152,11 @@ scheduler_events = {
 		"woocommerce_fusion.tasks.stock_update.update_stock_levels_for_all_enabled_items_in_background",
 		"woocommerce_fusion.tasks.sync_item_prices.run_item_price_sync_in_background",
 	],
+	"cron": {
+		"* * * * *": [
+			"woocommerce_fusion.tasks.batch.queue_manager.check_and_flush_all_servers",
+		],
+	},
 	# 	"monthly": [
 	# 		"woocommerce_fusion.tasks.monthly"
 	# 	],

--- a/woocommerce_fusion/overrides/selling/sales_order.py
+++ b/woocommerce_fusion/overrides/selling/sales_order.py
@@ -5,6 +5,7 @@ from erpnext.selling.doctype.sales_order.sales_order import SalesOrder
 from frappe import _
 from frappe.model.document import Document
 from frappe.model.naming import get_default_naming_series, make_autoname
+from frappe.utils import cstr
 
 from woocommerce_fusion.tasks.sync_sales_orders import run_sales_order_sync
 from woocommerce_fusion.woocommerce.woocommerce_api import (
@@ -23,7 +24,11 @@ class CustomSalesOrder(SalesOrder):
 	def autoname(self):
 		"""
 		If this is a WooCommerce-linked order, use the naming series defined in "WooCommerce Server"
-		or default to WEB[WooCommerce Order ID], e.g. WEB012142.
+		or default to WEB[site idx]-[WooCommerce order number], e.g. WEB1-002740.
+
+		The customer-facing WooCommerce order ``number`` (carried via flags from the sync) is used
+		when available, falling back to the WooCommerce ``id`` (post id). Because the order number
+		is not guaranteed unique (the post id is), a collision falls back to appending the id.
 		Else, name it normally.
 		"""
 		if self.woocommerce_id and self.woocommerce_server:
@@ -38,7 +43,19 @@ class CustomSalesOrder(SalesOrder):
 					(index for (index, d) in enumerate(sorted_list) if d["name"] == self.woocommerce_server),
 					None,
 				)
-				self.name = f"WEB{idx + 1}-{int(self.woocommerce_id):06}"  # Format with leading zeros to make it 6 digits
+				prefix = f"WEB{idx + 1}-"
+
+				order_number = cstr(self.flags.get("woocommerce_number")).strip()
+				# Use the customer-facing order number when available, else the legacy
+				# zero-padded post id format.
+				base = order_number if order_number else f"{int(self.woocommerce_id):06}"
+
+				name = f"{prefix}{base}"
+				# Order numbers are not guaranteed unique; the post id is, so disambiguate with it
+				if frappe.db.exists("Sales Order", name):
+					name = f"{prefix}{base}-{self.woocommerce_id}"
+
+				self.name = name
 		else:
 			naming_series = get_default_naming_series("Sales Order")
 			self.name = make_autoname(key=naming_series)

--- a/woocommerce_fusion/overrides/selling/test_sales_order.py
+++ b/woocommerce_fusion/overrides/selling/test_sales_order.py
@@ -96,34 +96,92 @@ class TestCustomSalesOrder(FrappeTestCase):
 			)
 		]
 		mock_frappe.get_cached_doc.return_value = frappe._dict({"sales_order_series": ""})
+		mock_frappe.db.exists.return_value = None
 
 		sales_order = create_so(woocommerce_id="123", woocommerce_server_url="https://somesite.co")
 
 		# Expect WEB[x]-[yyyyyy] where x = 1 because it's the first item servers list, and yyy = 000123 because the woocommerce id = 123
 		self.assertEqual(sales_order.name, "WEB1-000123")
 
+	@patch("woocommerce_fusion.overrides.selling.sales_order.frappe")
+	def test_sales_order_named_with_woocommerce_number_when_available(
+		self, mock_frappe, mock_get_woocommerce_order
+	):
+		"""
+		Test that the Sales Order is named using the customer-facing WooCommerce order number
+		(carried via flags) when it is available, rather than the WooCommerce id.
+		"""
+		mock_frappe.get_all.return_value = [
+			frappe._dict(
+				{
+					"creation": "2024-01-01",
+					"woocommerce_server_url": "https://somesite.co",
+					"name": "somesite.co",
+				}
+			)
+		]
+		mock_frappe.get_cached_doc.return_value = frappe._dict({"sales_order_series": ""})
+		mock_frappe.db.exists.return_value = None
 
-def create_so(woocommerce_id: str | None = None, woocommerce_server_url: str | None = None):
+		sales_order = create_so(
+			woocommerce_id="123",
+			woocommerce_server_url="https://somesite.co",
+			woocommerce_number="002740",
+		)
+
+		self.assertEqual(sales_order.name, "WEB1-002740")
+
+	@patch("woocommerce_fusion.overrides.selling.sales_order.frappe")
+	def test_sales_order_name_falls_back_to_id_on_collision(self, mock_frappe, mock_get_woocommerce_order):
+		"""
+		Test that when the order-number-based name already exists, the (unique) WooCommerce id is
+		appended to keep the Sales Order name unique.
+		"""
+		mock_frappe.get_all.return_value = [
+			frappe._dict(
+				{
+					"creation": "2024-01-01",
+					"woocommerce_server_url": "https://somesite.co",
+					"name": "somesite.co",
+				}
+			)
+		]
+		mock_frappe.get_cached_doc.return_value = frappe._dict({"sales_order_series": ""})
+		mock_frappe.db.exists.return_value = True
+
+		sales_order = create_so(
+			woocommerce_id="123",
+			woocommerce_server_url="https://somesite.co",
+			woocommerce_number="002740",
+		)
+
+		self.assertEqual(sales_order.name, "WEB1-002740-123")
+
+
+def create_so(
+	woocommerce_id: str | None = None,
+	woocommerce_server_url: str | None = None,
+	woocommerce_number: str | None = None,
+):
 	so = frappe.new_doc("Sales Order")
 
 	if woocommerce_server_url:
-		wc_server = frappe.get_doc(
-			{
-				"doctype": "WooCommerce Server",
-				"woocommerce_server_url": woocommerce_server_url,
-			}
-		)
-		if not wc_server:
+		existing = frappe.db.exists("WooCommerce Server", {"woocommerce_server_url": woocommerce_server_url})
+		if existing:
+			so.woocommerce_server = existing
+		else:
 			wc_server = frappe.new_doc("WooCommerce Server")
 			wc_server.woocommerce_server_url = woocommerce_server_url
-		wc_server.flags.ignore_mandatory = True
-		wc_server.save()
-		so.woocommerce_server = wc_server.name
+			wc_server.flags.ignore_mandatory = True
+			wc_server.save()
+			so.woocommerce_server = wc_server.name
 
 	so.customer = "_Test Customer"
 	so.company = "_Test Company"
 	so.transaction_date = date.today()
 	so.woocommerce_id = woocommerce_id
+	if woocommerce_number is not None:
+		so.flags.woocommerce_number = woocommerce_number
 
 	so.set_warehouse = "Finished Goods - _TC"
 	so.append(

--- a/woocommerce_fusion/patches.txt
+++ b/woocommerce_fusion/patches.txt
@@ -8,3 +8,4 @@ woocommerce_fusion.patches.v1.update_woocommerce_identifiers
 woocommerce_fusion.patches.v1.update_woocommerce_server_item_map
 woocommerce_fusion.patches.v1.enable_woocommerce_server_tax_settings
 woocommerce_fusion.patches.v1.set_shipping_tax_account
+woocommerce_fusion.patches.v1.add_batch_doctypes_to_log_settings

--- a/woocommerce_fusion/patches/v1/add_batch_doctypes_to_log_settings.py
+++ b/woocommerce_fusion/patches/v1/add_batch_doctypes_to_log_settings.py
@@ -1,0 +1,33 @@
+import frappe
+from frappe import _
+from frappe.core.doctype.log_settings.log_settings import _supports_log_clearing
+from frappe.utils.data import cint
+
+
+def execute():
+	"""
+	Register the Batch API log doctypes with Log Settings for automatic cleanup
+	"""
+	frappe.reload_doc("woocommerce", "doctype", "WooCommerce Batch Log")
+	frappe.reload_doc("woocommerce", "doctype", "WooCommerce Sync Queue")
+
+	WOOCOMMERCE_LOGTYPES_RETENTION = {
+		"WooCommerce Batch Log": 30,
+		"WooCommerce Sync Queue": 30,
+	}
+
+	log_settings = frappe.get_single("Log Settings")
+	existing_logtypes = {d.ref_doctype for d in log_settings.logs_to_clear}
+	added_logtypes = set()
+	for logtype, retention in WOOCOMMERCE_LOGTYPES_RETENTION.items():
+		if logtype not in existing_logtypes and _supports_log_clearing(logtype):
+			if not frappe.db.exists("DocType", logtype):
+				continue
+
+			log_settings.append("logs_to_clear", {"ref_doctype": logtype, "days": cint(retention)})
+			added_logtypes.add(logtype)
+			log_settings.save()
+			frappe.db.commit()
+
+	if added_logtypes:
+		print(_("Added default log doctypes: {}").format(",".join(added_logtypes)))

--- a/woocommerce_fusion/tasks/batch/__init__.py
+++ b/woocommerce_fusion/tasks/batch/__init__.py
@@ -1,0 +1,25 @@
+import frappe
+
+
+def get_item_sync_class(server_name: str):
+	"""Return the appropriate SynchroniseItem class based on server config."""
+	server = frappe.get_cached_doc("WooCommerce Server", server_name)
+	if server.enable_batch_api:
+		from woocommerce_fusion.tasks.batch.sync_items_batch import SynchroniseItemBatch
+
+		return SynchroniseItemBatch
+	from woocommerce_fusion.tasks.sync_items import SynchroniseItem
+
+	return SynchroniseItem
+
+
+def get_price_sync_class(server_name: str):
+	"""Return the appropriate SynchroniseItemPrice class based on server config."""
+	server = frappe.get_cached_doc("WooCommerce Server", server_name)
+	if server.enable_batch_api:
+		from woocommerce_fusion.tasks.batch.sync_item_prices_batch import SynchroniseItemPriceBatch
+
+		return SynchroniseItemPriceBatch
+	from woocommerce_fusion.tasks.sync_item_prices import SynchroniseItemPrice
+
+	return SynchroniseItemPrice

--- a/woocommerce_fusion/tasks/batch/batch_processor.py
+++ b/woocommerce_fusion/tasks/batch/batch_processor.py
@@ -388,7 +388,9 @@ class BatchProcessor:
 		)
 		batch_log.insert(ignore_permissions=True)
 		if not frappe.flags.in_test:
-			frappe.db.commit()
+			# Commit the WooCommerce Batch Log now so the audit record of what was sent to
+			# WooCommerce survives a later failure in the same flush.
+			frappe.db.commit()  # nosemgrep
 		return batch_log
 
 	def _finalise_batch_log(self, batch_log, success_count: int, fail_count: int):
@@ -397,7 +399,9 @@ class BatchProcessor:
 		batch_log.status = "Completed" if fail_count == 0 else "Failed" if success_count == 0 else "Partial"
 		batch_log.save(ignore_permissions=True)
 		if not frappe.flags.in_test:
-			frappe.db.commit()
+			# Commit the WooCommerce Batch Log now so the audit record of what was sent to
+			# WooCommerce survives a later failure in the same flush.
+			frappe.db.commit()  # nosemgrep
 
 	def _execute_product_batch(
 		self,
@@ -430,7 +434,9 @@ class BatchProcessor:
 			batch_log.failed_items = total
 			batch_log.save(ignore_permissions=True)
 			if not frappe.flags.in_test:
-				frappe.db.commit()
+				# Commit the WooCommerce Batch Log now so the audit record of what was sent to
+				# WooCommerce survives a later failure in the same flush.
+				frappe.db.commit()  # nosemgrep
 			return 0, total
 
 		batch_log.response_payload = json.dumps(result)
@@ -459,7 +465,9 @@ class BatchProcessor:
 		batch_log.status = "Completed" if fail_count == 0 else "Partial"
 		batch_log.save(ignore_permissions=True)
 		if not frappe.flags.in_test:
-			frappe.db.commit()
+			# Commit the WooCommerce Batch Log now so the audit record of what was sent to
+			# WooCommerce survives a later failure in the same flush.
+			frappe.db.commit()  # nosemgrep
 
 		return success_count, fail_count
 
@@ -478,7 +486,9 @@ class BatchProcessor:
 			batch_log.failed_items = total
 			batch_log.save(ignore_permissions=True)
 			if not frappe.flags.in_test:
-				frappe.db.commit()
+				# Commit the WooCommerce Batch Log now so the audit record of what was sent to
+				# WooCommerce survives a later failure in the same flush.
+				frappe.db.commit()  # nosemgrep
 			return 0, total
 
 		batch_log.response_payload = json.dumps(result)
@@ -498,7 +508,10 @@ class BatchProcessor:
 		batch_log.status = "Completed" if fail_count == 0 else "Partial"
 		batch_log.save(ignore_permissions=True)
 		if not frappe.flags.in_test:
-			frappe.db.commit()
+			# Commit the WooCommerce Batch Log now so the audit record of what was sent to
+			# WooCommerce survives a later failure in the same flush. Skipped under test to keep
+			# FrappeTestCase rollback isolation.
+			frappe.db.commit()  # nosemgrep
 
 		return success_count, fail_count
 

--- a/woocommerce_fusion/tasks/batch/batch_processor.py
+++ b/woocommerce_fusion/tasks/batch/batch_processor.py
@@ -77,7 +77,7 @@ class BatchProcessor:
 		batch_create: list[tuple] = []
 		batch_update: list[tuple] = []
 
-		# Creates — build payload from ERPNext item data
+		# Creates - build payload from ERPNext item data
 		for row in rows_to_create:
 			# Variation orphaning: a variation cannot be created without its parent's WC ID
 			if row.wc_resource_type == "product_variation" and not row.parent_woocommerce_id:
@@ -101,7 +101,7 @@ class BatchProcessor:
 				self._mark_failed(row.name, frappe.get_traceback(), None)
 				pre_fail += 1
 
-		# Updates — conflict resolution against fresh WC data
+		# Updates - conflict resolution against fresh WC data
 		for row in rows_to_update:
 			wc_product = wc_products_map.get(str(row.woocommerce_id))
 			if not wc_product:
@@ -116,7 +116,7 @@ class BatchProcessor:
 				iws = item_for_sync.item_woocommerce_server
 
 				# Skip (don't break the batch) if the WC product type no longer matches the
-				# ERPNext item — sending such an update would corrupt the product.
+				# ERPNext item - sending such an update would corrupt the product.
 				expected_type = _expected_wc_type(item)
 				if wc_product.type and expected_type != wc_product.type:
 					frappe.log_error(
@@ -275,20 +275,27 @@ class BatchProcessor:
 		)
 
 		try:
-			wc_orders = frappe.get_doc({"doctype": "WooCommerce Order"}).get_list(
-				args={
-					"filters": [["WooCommerce Order", "id", "in", [str(i) for i in wc_ids]]],
-					"page_length": 100,
-					"start": 0,
-					"servers": [self.server_name],
-					"as_doc": True,
-				}
-			)
-			wc_orders_map = {str(o.id): o for o in (wc_orders or [])}
+			wc_orders_map = self._bulk_get_orders(wc_ids)
 		except Exception:
 			self._mark_all_failed(rows, f"Bulk GET failed: {frappe.get_traceback()}", batch_log.name)
 			self._finalise_batch_log(batch_log, 0, len(rows))
 			return 0, len(rows)
+
+		# Orders not returned by the default lookup are trashed or permanently deleted. Trashed
+		# orders are excluded from the default WooCommerce listing and there is no endpoint that
+		# returns trashed + non-trashed together, so re-fetch (with status=trash) only those that
+		# have a linked Sales Order - those are the ones whose status we still need to update.
+		linked_so_map = {}
+		for row in rows:
+			if str(row.woocommerce_id) not in wc_orders_map:
+				linked_so = self._linked_sales_order(row.woocommerce_id)
+				if linked_so:
+					linked_so_map[str(row.woocommerce_id)] = linked_so
+		if linked_so_map:
+			try:
+				wc_orders_map.update(self._bulk_get_orders(list(linked_so_map.keys()), status="trash"))
+			except Exception:
+				pass  # fall through; any still-missing order is flagged below
 
 		from woocommerce_fusion.tasks.sync_sales_orders import run_sales_order_sync
 
@@ -298,23 +305,14 @@ class BatchProcessor:
 		for row in rows:
 			wc_order = wc_orders_map.get(str(row.woocommerce_id))
 			if not wc_order:
-				# Not returned by the lookup → the order is trashed or permanently deleted.
-				# Inbound sync only has anything to do if a Sales Order was already created from
-				# it; with no linked Sales Order there is nothing to update, so this is a no-op
-				# (Skipped), not a failure.
-				linked_so = frappe.db.get_value(
-					"Sales Order",
-					{
-						"woocommerce_id": str(row.woocommerce_id),
-						"woocommerce_server": self.server_name,
-					},
-					"name",
-				)
+				# Still not found. If a Sales Order is linked, the order was permanently deleted
+				# (not just trashed) - flag it. Otherwise there is nothing to sync, so it is a no-op.
+				linked_so = linked_so_map.get(str(row.woocommerce_id))
 				if linked_so:
 					self._mark_failed(
 						row.name,
-						f"Order {row.woocommerce_id} is trashed/deleted in WooCommerce but is linked to "
-						f"Sales Order {linked_so}; it could not be re-fetched to update the status.",
+						f"Order {row.woocommerce_id} could not be fetched from WooCommerce "
+						f"(permanently deleted?) but is linked to Sales Order {linked_so}.",
 						batch_log.name,
 					)
 					fail_count += 1
@@ -322,7 +320,7 @@ class BatchProcessor:
 					self._mark_skipped(
 						row,
 						f"Order {row.woocommerce_id} is not present in WooCommerce (trashed/deleted) "
-						"and has no linked Sales Order — nothing to sync.",
+						"and has no linked Sales Order - nothing to sync.",
 					)
 					skipped_count += 1
 				continue
@@ -350,6 +348,31 @@ class BatchProcessor:
 			}
 		)
 		return {str(p.woocommerce_id): p for p in (wc_products or [])}
+
+	def _bulk_get_orders(self, wc_ids: list, status: str | None = None) -> dict:
+		"""Bulk-fetch WooCommerce Orders by id. Pass status='trash' to fetch trashed orders
+		(which the default listing excludes)."""
+		filters = [["WooCommerce Order", "id", "in", [str(i) for i in wc_ids]]]
+		if status:
+			filters.append(["WooCommerce Order", "status", "=", status])
+		wc_orders = frappe.get_doc({"doctype": "WooCommerce Order"}).get_list(
+			args={
+				"filters": filters,
+				"page_length": 100,
+				"start": 0,
+				"servers": [self.server_name],
+				"as_doc": True,
+			}
+		)
+		return {str(o.id): o for o in (wc_orders or [])}
+
+	def _linked_sales_order(self, woocommerce_id: str) -> str | None:
+		"""Return the name of the Sales Order linked to this WooCommerce order id, if any."""
+		return frappe.db.get_value(
+			"Sales Order",
+			{"woocommerce_id": str(woocommerce_id), "woocommerce_server": self.server_name},
+			"name",
+		)
 
 	def _create_batch_log(self, resource_type: str, flush_reason: str, total_items: int, payload: dict):
 		batch_log = frappe.get_doc(

--- a/woocommerce_fusion/tasks/batch/batch_processor.py
+++ b/woocommerce_fusion/tasks/batch/batch_processor.py
@@ -4,7 +4,6 @@ import frappe
 from frappe.utils import get_datetime, now_datetime
 
 from woocommerce_fusion.tasks.sync_items import ERPNextItemToSync, SynchroniseItem
-from woocommerce_fusion.tasks.utils import commit_unless_in_test
 from woocommerce_fusion.woocommerce.doctype.woocommerce_order.woocommerce_order import (
 	WooCommerceOrder,
 )
@@ -388,7 +387,8 @@ class BatchProcessor:
 			}
 		)
 		batch_log.insert(ignore_permissions=True)
-		commit_unless_in_test()
+		if not frappe.flags.in_test:
+			frappe.db.commit()
 		return batch_log
 
 	def _finalise_batch_log(self, batch_log, success_count: int, fail_count: int):
@@ -396,7 +396,8 @@ class BatchProcessor:
 		batch_log.failed_items = fail_count
 		batch_log.status = "Completed" if fail_count == 0 else "Failed" if success_count == 0 else "Partial"
 		batch_log.save(ignore_permissions=True)
-		commit_unless_in_test()
+		if not frappe.flags.in_test:
+			frappe.db.commit()
 
 	def _execute_product_batch(
 		self,
@@ -428,7 +429,8 @@ class BatchProcessor:
 			batch_log.status = "Failed"
 			batch_log.failed_items = total
 			batch_log.save(ignore_permissions=True)
-			commit_unless_in_test()
+			if not frappe.flags.in_test:
+				frappe.db.commit()
 			return 0, total
 
 		batch_log.response_payload = json.dumps(result)
@@ -456,7 +458,8 @@ class BatchProcessor:
 		batch_log.failed_items = fail_count
 		batch_log.status = "Completed" if fail_count == 0 else "Partial"
 		batch_log.save(ignore_permissions=True)
-		commit_unless_in_test()
+		if not frappe.flags.in_test:
+			frappe.db.commit()
 
 		return success_count, fail_count
 
@@ -474,7 +477,8 @@ class BatchProcessor:
 			batch_log.status = "Failed"
 			batch_log.failed_items = total
 			batch_log.save(ignore_permissions=True)
-			commit_unless_in_test()
+			if not frappe.flags.in_test:
+				frappe.db.commit()
 			return 0, total
 
 		batch_log.response_payload = json.dumps(result)
@@ -493,7 +497,8 @@ class BatchProcessor:
 		batch_log.failed_items = fail_count
 		batch_log.status = "Completed" if fail_count == 0 else "Partial"
 		batch_log.save(ignore_permissions=True)
-		commit_unless_in_test()
+		if not frappe.flags.in_test:
+			frappe.db.commit()
 
 		return success_count, fail_count
 

--- a/woocommerce_fusion/tasks/batch/batch_processor.py
+++ b/woocommerce_fusion/tasks/batch/batch_processor.py
@@ -1,0 +1,595 @@
+import json
+
+import frappe
+from frappe.utils import get_datetime, now_datetime
+
+from woocommerce_fusion.tasks.sync_items import ERPNextItemToSync, SynchroniseItem
+from woocommerce_fusion.tasks.utils import commit_unless_in_test
+from woocommerce_fusion.woocommerce.doctype.woocommerce_order.woocommerce_order import (
+	WooCommerceOrder,
+)
+from woocommerce_fusion.woocommerce.doctype.woocommerce_product.woocommerce_product import (
+	WooCommerceProduct,
+)
+
+
+class BatchProcessor:
+	"""
+	Unified processor for all sync types and directions. Routes each chunk of queue rows
+	to the correct handler based on (sync_type, direction).
+	"""
+
+	def __init__(self, server_name: str):
+		self.server_name = server_name
+		self.server = frappe.get_cached_doc("WooCommerce Server", server_name)
+
+	# ── Routing ─────────────────────────────────────────────────────────────────
+
+	def process_chunk(
+		self,
+		rows: list,
+		resource_type: str,
+		parent_id: str | None,
+		flush_reason: str,
+	) -> tuple[int, int]:
+		"""
+		Route to the correct handler based on (sync_type, direction).
+		Returns (successful_count, failed_count).
+		"""
+		if not rows:
+			return 0, 0
+
+		sync_type = rows[0].sync_type
+		direction = rows[0].direction
+
+		if sync_type == "order" and direction == "outbound":
+			return self._process_order_chunk(rows, flush_reason)
+		if sync_type == "order" and direction == "inbound":
+			return self._process_order_inbound_chunk(rows, flush_reason)
+		if direction == "inbound":
+			return self._process_item_inbound_chunk(rows, flush_reason)
+		# item / item_price / stock + outbound → products batch endpoint
+		if sync_type in ("item_price", "stock"):
+			return self._process_simple_update_chunk(rows, resource_type, parent_id, flush_reason)
+		return self._process_item_outbound_chunk(rows, resource_type, parent_id, flush_reason)
+
+	# ── Item outbound (full build + conflict resolution) ─────────────────────────
+
+	def _process_item_outbound_chunk(
+		self, rows: list, resource_type: str, parent_id: str | None, flush_reason: str
+	) -> tuple[int, int]:
+		pre_success = 0
+		pre_fail = 0
+
+		rows_to_create = [r for r in rows if not r.woocommerce_id]
+		rows_to_update = [r for r in rows if r.woocommerce_id]
+
+		# Bulk GET existing WC products (1 API call)
+		wc_products_map: dict[str, WooCommerceProduct] = {}
+		if rows_to_update:
+			try:
+				wc_products_map = self._bulk_get_products([r.woocommerce_id for r in rows_to_update])
+			except Exception:
+				self._mark_all_failed(rows_to_update, f"Bulk GET failed: {frappe.get_traceback()}", None)
+				pre_fail += len(rows_to_update)
+				rows_to_update = []
+
+		batch_create: list[tuple] = []
+		batch_update: list[tuple] = []
+
+		# Creates — build payload from ERPNext item data
+		for row in rows_to_create:
+			# Variation orphaning: a variation cannot be created without its parent's WC ID
+			if row.wc_resource_type == "product_variation" and not row.parent_woocommerce_id:
+				self._mark_failed(
+					row.name,
+					"Cannot create variation: parent product has no WooCommerce ID yet. "
+					"Sync the parent (template) item first.",
+					None,
+				)
+				pre_fail += 1
+				continue
+			try:
+				item = frappe.get_doc("Item", row.reference_name)
+				item_for_sync = ERPNextItemToSync(
+					item=item, item_woocommerce_server_idx=row.item_woocommerce_server_idx
+				)
+				sync = SynchroniseItem(item=item_for_sync)
+				payload = sync._build_create_payload(item_for_sync)
+				batch_create.append((row, payload))
+			except Exception:
+				self._mark_failed(row.name, frappe.get_traceback(), None)
+				pre_fail += 1
+
+		# Updates — conflict resolution against fresh WC data
+		for row in rows_to_update:
+			wc_product = wc_products_map.get(str(row.woocommerce_id))
+			if not wc_product:
+				self._mark_failed(row.name, "Product not found in WooCommerce", None)
+				pre_fail += 1
+				continue
+			try:
+				item = frappe.get_doc("Item", row.reference_name)
+				item_for_sync = ERPNextItemToSync(
+					item=item, item_woocommerce_server_idx=row.item_woocommerce_server_idx
+				)
+				iws = item_for_sync.item_woocommerce_server
+
+				# Skip (don't break the batch) if the WC product type no longer matches the
+				# ERPNext item — sending such an update would corrupt the product.
+				expected_type = _expected_wc_type(item)
+				if wc_product.type and expected_type != wc_product.type:
+					frappe.log_error(
+						"WooCommerce Batch Warning",
+						f"Skipping {row.reference_name}: WC product type '{wc_product.type}' "
+						f"does not match expected '{expected_type}'",
+					)
+					self._mark_skipped(row, "Product type mismatch")
+					pre_success += 1
+					continue
+
+				wc_date_modified = wc_product.woocommerce_date_modified
+
+				# Mirror the single-call conflict resolution: only treat this as an inbound
+				# conflict (skip the outbound push) when WooCommerce has changed since our last
+				# sync AND is newer than the ERPNext item. A matching sync hash means the last
+				# WC change was made by us, so it is safe to push the local edits.
+				if wc_date_modified != iws.woocommerce_last_sync_hash and get_datetime(
+					wc_date_modified
+				) > get_datetime(item.modified):
+					self._mark_completed(
+						row,
+						{"id": int(row.woocommerce_id), "date_modified": wc_date_modified},
+						None,
+						"update",
+					)
+					pre_success += 1
+					continue
+
+				sync = SynchroniseItem(item=item_for_sync, woocommerce_product=wc_product)
+				payload = sync._build_update_payload(item_for_sync)
+				if payload:
+					batch_update.append((row, payload))
+				else:
+					self._mark_completed(
+						row,
+						{"id": int(row.woocommerce_id), "date_modified": wc_date_modified},
+						None,
+						"update",
+					)
+					pre_success += 1
+			except Exception:
+				self._mark_failed(row.name, frappe.get_traceback(), None)
+				pre_fail += 1
+
+		if not batch_create and not batch_update:
+			return pre_success, pre_fail
+
+		success, fail = self._execute_product_batch(
+			batch_create, batch_update, resource_type, parent_id, flush_reason
+		)
+		return pre_success + success, pre_fail + fail
+
+	# ── item_price / stock outbound (payload from extra_data) ────────────────────
+
+	def _process_simple_update_chunk(
+		self, rows: list, resource_type: str, parent_id: str | None, flush_reason: str
+	) -> tuple[int, int]:
+		pre_success = 0
+		pre_fail = 0
+		batch_update: list[tuple] = []
+
+		for row in rows:
+			if not row.woocommerce_id:
+				self._mark_failed(row.name, "Missing WooCommerce ID", None)
+				pre_fail += 1
+				continue
+			extra = json.loads(row.extra_data) if row.extra_data else {}
+			if not extra:
+				self._mark_completed(row, {"id": int(row.woocommerce_id)}, None, "update")
+				pre_success += 1
+				continue
+			batch_update.append((row, extra))
+
+		if not batch_update:
+			return pre_success, pre_fail
+
+		success, fail = self._execute_product_batch([], batch_update, resource_type, parent_id, flush_reason)
+		return pre_success + success, pre_fail + fail
+
+	# ── Item inbound (bulk GET → ERPNext writes) ─────────────────────────────────
+
+	def _process_item_inbound_chunk(self, rows: list, flush_reason: str) -> tuple[int, int]:
+		wc_ids = [r.woocommerce_id for r in rows if r.woocommerce_id]
+		if not wc_ids:
+			self._mark_all_failed(rows, "Missing WooCommerce ID for inbound sync", None)
+			return 0, len(rows)
+
+		batch_log = self._create_batch_log(
+			"product",
+			flush_reason,
+			len(rows),
+			{"operation": "inbound", "woocommerce_ids": [str(i) for i in wc_ids]},
+		)
+
+		try:
+			wc_products_map = self._bulk_get_products(wc_ids)
+		except Exception:
+			self._mark_all_failed(rows, f"Bulk GET failed: {frappe.get_traceback()}", batch_log.name)
+			self._finalise_batch_log(batch_log, 0, len(rows))
+			return 0, len(rows)
+
+		success_count = 0
+		fail_count = 0
+		for row in rows:
+			wc_product = wc_products_map.get(str(row.woocommerce_id))
+			if not wc_product:
+				self._mark_failed(
+					row.name, f"Product {row.woocommerce_id} not found in WooCommerce", batch_log.name
+				)
+				fail_count += 1
+				continue
+			try:
+				# Use the base class explicitly so the inbound write happens directly
+				SynchroniseItem(woocommerce_product=wc_product).run()
+				self._mark_completed(row, {"id": int(row.woocommerce_id)}, batch_log.name, "inbound")
+				success_count += 1
+			except Exception:
+				self._mark_failed(row.name, frappe.get_traceback(), batch_log.name)
+				fail_count += 1
+
+		self._finalise_batch_log(batch_log, success_count, fail_count)
+		return success_count, fail_count
+
+	# ── Order outbound (batch POST to /orders/batch) ─────────────────────────────
+
+	def _process_order_chunk(self, rows: list, flush_reason: str) -> tuple[int, int]:
+		batch_update: list[tuple] = []
+		pre_fail = 0
+		for row in rows:
+			if row.woocommerce_id and row.reference_name:
+				batch_update.append((row, {"status": row.reference_name}))
+			else:
+				self._mark_failed(row.name, "Missing WC order ID or target status", None)
+				pre_fail += 1
+
+		if not batch_update:
+			return 0, pre_fail
+
+		success, fail = self._execute_order_batch(batch_update, flush_reason)
+		return success, pre_fail + fail
+
+	# ── Order inbound (bulk GET → ERPNext Sales Orders) ──────────────────────────
+
+	def _process_order_inbound_chunk(self, rows: list, flush_reason: str) -> tuple[int, int]:
+		wc_ids = [r.woocommerce_id for r in rows if r.woocommerce_id]
+		if not wc_ids:
+			self._mark_all_failed(rows, "Missing WooCommerce ID for inbound order sync", None)
+			return 0, len(rows)
+
+		batch_log = self._create_batch_log(
+			"order",
+			flush_reason,
+			len(rows),
+			{"operation": "inbound", "woocommerce_ids": [str(i) for i in wc_ids]},
+		)
+
+		try:
+			wc_orders = frappe.get_doc({"doctype": "WooCommerce Order"}).get_list(
+				args={
+					"filters": [["WooCommerce Order", "id", "in", [str(i) for i in wc_ids]]],
+					"page_length": 100,
+					"start": 0,
+					"servers": [self.server_name],
+					"as_doc": True,
+				}
+			)
+			wc_orders_map = {str(o.id): o for o in (wc_orders or [])}
+		except Exception:
+			self._mark_all_failed(rows, f"Bulk GET failed: {frappe.get_traceback()}", batch_log.name)
+			self._finalise_batch_log(batch_log, 0, len(rows))
+			return 0, len(rows)
+
+		from woocommerce_fusion.tasks.sync_sales_orders import run_sales_order_sync
+
+		success_count = 0
+		fail_count = 0
+		skipped_count = 0
+		for row in rows:
+			wc_order = wc_orders_map.get(str(row.woocommerce_id))
+			if not wc_order:
+				# Not returned by the lookup → the order is trashed or permanently deleted.
+				# Inbound sync only has anything to do if a Sales Order was already created from
+				# it; with no linked Sales Order there is nothing to update, so this is a no-op
+				# (Skipped), not a failure.
+				linked_so = frappe.db.get_value(
+					"Sales Order",
+					{
+						"woocommerce_id": str(row.woocommerce_id),
+						"woocommerce_server": self.server_name,
+					},
+					"name",
+				)
+				if linked_so:
+					self._mark_failed(
+						row.name,
+						f"Order {row.woocommerce_id} is trashed/deleted in WooCommerce but is linked to "
+						f"Sales Order {linked_so}; it could not be re-fetched to update the status.",
+						batch_log.name,
+					)
+					fail_count += 1
+				else:
+					self._mark_skipped(
+						row,
+						f"Order {row.woocommerce_id} is not present in WooCommerce (trashed/deleted) "
+						"and has no linked Sales Order — nothing to sync.",
+					)
+					skipped_count += 1
+				continue
+			try:
+				run_sales_order_sync(woocommerce_order=wc_order)
+				self._mark_completed(row, {"id": int(row.woocommerce_id)}, batch_log.name, "inbound")
+				success_count += 1
+			except Exception:
+				self._mark_failed(row.name, frappe.get_traceback(), batch_log.name)
+				fail_count += 1
+
+		self._finalise_batch_log(batch_log, success_count + skipped_count, fail_count)
+		return success_count + skipped_count, fail_count
+
+	# ── Batch execution helpers ──────────────────────────────────────────────────
+
+	def _bulk_get_products(self, wc_ids: list) -> dict:
+		wc_products = frappe.get_doc({"doctype": "WooCommerce Product"}).get_list(
+			args={
+				"filters": [["WooCommerce Product", "id", "in", [str(i) for i in wc_ids]]],
+				"page_length": 100,
+				"start": 0,
+				"servers": [self.server_name],
+				"as_doc": True,
+			}
+		)
+		return {str(p.woocommerce_id): p for p in (wc_products or [])}
+
+	def _create_batch_log(self, resource_type: str, flush_reason: str, total_items: int, payload: dict):
+		batch_log = frappe.get_doc(
+			{
+				"doctype": "WooCommerce Batch Log",
+				"woocommerce_server": self.server_name,
+				"resource_type": resource_type,
+				"flush_reason": flush_reason,
+				"status": "Processing",
+				"total_items": total_items,
+				"flushed_at": now_datetime(),
+				"request_payload": json.dumps(payload),
+			}
+		)
+		batch_log.insert(ignore_permissions=True)
+		commit_unless_in_test()
+		return batch_log
+
+	def _finalise_batch_log(self, batch_log, success_count: int, fail_count: int):
+		batch_log.successful_items = success_count
+		batch_log.failed_items = fail_count
+		batch_log.status = "Completed" if fail_count == 0 else "Failed" if success_count == 0 else "Partial"
+		batch_log.save(ignore_permissions=True)
+		commit_unless_in_test()
+
+	def _execute_product_batch(
+		self,
+		batch_create: list,
+		batch_update: list,
+		resource_type: str,
+		parent_id: str | None,
+		flush_reason: str,
+	) -> tuple[int, int]:
+		batch_payload = {}
+		if batch_create:
+			batch_payload["create"] = [p for _, p in batch_create]
+		if batch_update:
+			batch_payload["update"] = [{"id": int(r.woocommerce_id), **p} for r, p in batch_update]
+
+		total = len(batch_create) + len(batch_update)
+		all_rows = [r for r, _ in batch_create] + [r for r, _ in batch_update]
+		batch_log = self._create_batch_log(resource_type, flush_reason, total, batch_payload)
+
+		try:
+			result = WooCommerceProduct.batch_update(
+				server_name=self.server_name,
+				payload=batch_payload,
+				parent_id=parent_id if resource_type == "product_variation" else None,
+			)
+		except Exception:
+			error = frappe.get_traceback()
+			self._mark_all_failed(all_rows, error, batch_log.name)
+			batch_log.status = "Failed"
+			batch_log.failed_items = total
+			batch_log.save(ignore_permissions=True)
+			commit_unless_in_test()
+			return 0, total
+
+		batch_log.response_payload = json.dumps(result)
+
+		success_count = 0
+		fail_count = 0
+
+		for (queue_row, _), wc_result in zip(batch_create, result.get("create", []), strict=False):
+			if "error" in wc_result:
+				self._mark_failed(queue_row.name, json.dumps(wc_result["error"]), batch_log.name)
+				fail_count += 1
+			else:
+				self._mark_completed(queue_row, wc_result, batch_log.name, "create")
+				success_count += 1
+
+		for (queue_row, _), wc_result in zip(batch_update, result.get("update", []), strict=False):
+			if "error" in wc_result:
+				self._mark_failed(queue_row.name, json.dumps(wc_result["error"]), batch_log.name)
+				fail_count += 1
+			else:
+				self._mark_completed(queue_row, wc_result, batch_log.name, "update")
+				success_count += 1
+
+		batch_log.successful_items = success_count
+		batch_log.failed_items = fail_count
+		batch_log.status = "Completed" if fail_count == 0 else "Partial"
+		batch_log.save(ignore_permissions=True)
+		commit_unless_in_test()
+
+		return success_count, fail_count
+
+	def _execute_order_batch(self, batch_update: list, flush_reason: str) -> tuple[int, int]:
+		batch_payload = {"update": [{"id": int(r.woocommerce_id), **p} for r, p in batch_update]}
+		total = len(batch_update)
+		all_rows = [r for r, _ in batch_update]
+		batch_log = self._create_batch_log("order", flush_reason, total, batch_payload)
+
+		try:
+			result = WooCommerceOrder.batch_update(server_name=self.server_name, payload=batch_payload)
+		except Exception:
+			error = frappe.get_traceback()
+			self._mark_all_failed(all_rows, error, batch_log.name)
+			batch_log.status = "Failed"
+			batch_log.failed_items = total
+			batch_log.save(ignore_permissions=True)
+			commit_unless_in_test()
+			return 0, total
+
+		batch_log.response_payload = json.dumps(result)
+
+		success_count = 0
+		fail_count = 0
+		for (queue_row, _), wc_result in zip(batch_update, result.get("update", []), strict=False):
+			if "error" in wc_result:
+				self._mark_failed(queue_row.name, json.dumps(wc_result["error"]), batch_log.name)
+				fail_count += 1
+			else:
+				self._mark_completed(queue_row, wc_result, batch_log.name, "order")
+				success_count += 1
+
+		batch_log.successful_items = success_count
+		batch_log.failed_items = fail_count
+		batch_log.status = "Completed" if fail_count == 0 else "Partial"
+		batch_log.save(ignore_permissions=True)
+		commit_unless_in_test()
+
+		return success_count, fail_count
+
+	# ── Row bookkeeping ──────────────────────────────────────────────────────────
+
+	def _mark_completed(self, queue_row, wc_result: dict, batch_log_name: str | None, operation: str):
+		updates = {"status": "Completed"}
+		if batch_log_name:
+			updates["batch_log"] = batch_log_name
+		if wc_result.get("id"):
+			updates["woocommerce_id"] = str(wc_result["id"])
+		frappe.db.set_value("WooCommerce Sync Queue", queue_row.name, updates, update_modified=False)
+
+		wc_id = wc_result.get("id")
+		date_modified = wc_result.get("date_modified")
+
+		if operation == "create" and queue_row.reference_name and wc_id:
+			_write_woocommerce_id_to_item(
+				item_code=queue_row.reference_name,
+				server_name=self.server_name,
+				woocommerce_id=str(wc_id),
+				date_modified=date_modified,
+			)
+		elif operation == "update" and date_modified and queue_row.woocommerce_id:
+			_set_sync_hash(
+				server_name=self.server_name,
+				woocommerce_id=str(queue_row.woocommerce_id),
+				date_modified=date_modified,
+			)
+
+	def _mark_skipped(self, queue_row, reason: str):
+		frappe.db.set_value(
+			"WooCommerce Sync Queue",
+			queue_row.name,
+			{"status": "Skipped", "error_message": reason[:2000]},
+			update_modified=False,
+		)
+
+	def _mark_failed(self, queue_row_name: str, error: str, batch_log_name: str | None):
+		updates = {"status": "Failed", "error_message": error[:2000]}
+		if batch_log_name:
+			updates["batch_log"] = batch_log_name
+		frappe.db.set_value("WooCommerce Sync Queue", queue_row_name, updates, update_modified=False)
+
+		ctx = (
+			frappe.db.get_value(
+				"WooCommerce Sync Queue",
+				queue_row_name,
+				[
+					"woocommerce_server",
+					"sync_type",
+					"direction",
+					"wc_resource_type",
+					"woocommerce_id",
+					"reference_doctype",
+					"reference_name",
+				],
+				as_dict=True,
+			)
+			or {}
+		)
+		frappe.log_error(
+			"WooCommerce Batch Error",
+			f"Queue row: {queue_row_name}\n"
+			f"Server: {ctx.get('woocommerce_server')}\n"
+			f"Sync: {ctx.get('sync_type')} / {ctx.get('direction')} ({ctx.get('wc_resource_type')})\n"
+			f"WooCommerce ID: {ctx.get('woocommerce_id')}\n"
+			f"Reference: {ctx.get('reference_doctype') or ''} {ctx.get('reference_name') or ''}\n"
+			f"Batch Log: {batch_log_name or '-'}\n\n"
+			f"{error}",
+		)
+
+	def _mark_all_failed(self, rows: list, error: str, batch_log_name: str | None):
+		for row in rows:
+			self._mark_failed(row.name, error, batch_log_name)
+
+
+def _expected_wc_type(item) -> str:
+	"""Return the WooCommerce product type expected for an ERPNext Item."""
+	if item.has_variants:
+		return "variable"
+	if item.variant_of:
+		return "variation"
+	return "simple"
+
+
+def _write_woocommerce_id_to_item(
+	item_code: str, server_name: str, woocommerce_id: str, date_modified: str | None
+):
+	"""Write back the newly assigned WooCommerce ID to the Item's child table row."""
+	child_row = frappe.db.get_value(
+		"Item WooCommerce Server",
+		{"parent": item_code, "woocommerce_server": server_name},
+		"name",
+	)
+	if child_row:
+		frappe.db.set_value(
+			"Item WooCommerce Server",
+			child_row,
+			{
+				"woocommerce_id": woocommerce_id,
+				"woocommerce_last_sync_hash": date_modified or "",
+				"enabled": 1,
+			},
+			update_modified=False,
+		)
+
+
+def _set_sync_hash(server_name: str, woocommerce_id: str, date_modified: str):
+	child_row = frappe.db.get_value(
+		"Item WooCommerce Server",
+		{"woocommerce_server": server_name, "woocommerce_id": woocommerce_id},
+		"name",
+	)
+	if child_row:
+		frappe.db.set_value(
+			"Item WooCommerce Server",
+			child_row,
+			"woocommerce_last_sync_hash",
+			date_modified,
+			update_modified=False,
+		)

--- a/woocommerce_fusion/tasks/batch/queue_manager.py
+++ b/woocommerce_fusion/tasks/batch/queue_manager.py
@@ -75,7 +75,9 @@ def flush_pending(server_name: str, reason: str = "manual") -> dict:
 		update_modified=False,
 	)
 	if not frappe.flags.in_test:
-		frappe.db.commit()
+		# Commit the row claim (status=Processing) immediately so a concurrent flush worker
+		# cannot re-claim and double-process the same queue rows.
+		frappe.db.commit()  # nosemgrep
 
 	# Group by (wc_resource_type, parent_woocommerce_id, sync_type, direction)
 	groups: dict[tuple, list] = {}

--- a/woocommerce_fusion/tasks/batch/queue_manager.py
+++ b/woocommerce_fusion/tasks/batch/queue_manager.py
@@ -4,7 +4,6 @@ import frappe
 from frappe.utils import get_datetime, now_datetime
 
 from woocommerce_fusion.tasks.batch.batch_processor import BatchProcessor
-from woocommerce_fusion.tasks.utils import commit_unless_in_test
 
 
 def should_flush(server_name: str) -> tuple[bool, str]:
@@ -75,7 +74,8 @@ def flush_pending(server_name: str, reason: str = "manual") -> dict:
 		"Processing",
 		update_modified=False,
 	)
-	commit_unless_in_test()
+	if not frappe.flags.in_test:
+		frappe.db.commit()
 
 	# Group by (wc_resource_type, parent_woocommerce_id, sync_type, direction)
 	groups: dict[tuple, list] = {}

--- a/woocommerce_fusion/tasks/batch/queue_manager.py
+++ b/woocommerce_fusion/tasks/batch/queue_manager.py
@@ -1,0 +1,173 @@
+from datetime import timedelta
+
+import frappe
+from frappe.utils import get_datetime, now_datetime
+
+from woocommerce_fusion.tasks.batch.batch_processor import BatchProcessor
+from woocommerce_fusion.tasks.utils import commit_unless_in_test
+
+
+def should_flush(server_name: str) -> tuple[bool, str]:
+	"""
+	Returns (should_flush, reason). Flushes if:
+	  - pending count >= batch_size_limit, OR
+	  - oldest pending entry is older than flush_interval_minutes
+	"""
+	server = frappe.get_cached_doc("WooCommerce Server", server_name)
+	batch_size_limit = server.batch_size_limit or 100
+	flush_interval = server.batch_flush_interval_minutes or 1
+
+	pending_count = frappe.db.count(
+		"WooCommerce Sync Queue",
+		{"woocommerce_server": server_name, "status": "Pending"},
+	)
+
+	if pending_count >= batch_size_limit:
+		return True, "buffer_full"
+
+	if pending_count > 0:
+		oldest_creation = frappe.db.get_value(
+			"WooCommerce Sync Queue",
+			{"woocommerce_server": server_name, "status": "Pending"},
+			"creation",
+			order_by="creation asc",
+		)
+		if oldest_creation:
+			age = now_datetime() - get_datetime(oldest_creation)
+			if age >= timedelta(minutes=flush_interval):
+				return True, "timer_elapsed"
+
+	return False, ""
+
+
+def flush_pending(server_name: str, reason: str = "manual") -> dict:
+	"""
+	Flush all Pending queue entries for server_name as one or more batch calls.
+	"""
+	pending_rows = frappe.db.get_all(
+		"WooCommerce Sync Queue",
+		filters={"woocommerce_server": server_name, "status": "Pending"},
+		fields=[
+			"name",
+			"sync_type",
+			"direction",
+			"wc_resource_type",
+			"parent_woocommerce_id",
+			"woocommerce_id",
+			"reference_doctype",
+			"reference_name",
+			"item_woocommerce_server_idx",
+			"triggered_by",
+			"extra_data",
+		],
+		order_by="creation asc",
+	)
+
+	if not pending_rows:
+		return {"flushed": 0, "success": 0, "failed": 0}
+
+	# Lock: mark all current Pending rows as Processing
+	names = [r.name for r in pending_rows]
+	frappe.db.set_value(
+		"WooCommerce Sync Queue",
+		{"name": ["in", names]},
+		"status",
+		"Processing",
+		update_modified=False,
+	)
+	commit_unless_in_test()
+
+	# Group by (wc_resource_type, parent_woocommerce_id, sync_type, direction)
+	groups: dict[tuple, list] = {}
+	for row in pending_rows:
+		key = (row.wc_resource_type, row.parent_woocommerce_id or "", row.sync_type, row.direction)
+		groups.setdefault(key, []).append(row)
+
+	processor = BatchProcessor(server_name=server_name)
+	server = frappe.get_cached_doc("WooCommerce Server", server_name)
+	chunk_size = server.batch_size_limit or 100
+
+	totals = {"success": 0, "failed": 0}
+
+	def run_chunks(resource_type: str, parent_id: str | None, rows: list) -> None:
+		for chunk_start in range(0, len(rows), chunk_size):
+			chunk = rows[chunk_start : chunk_start + chunk_size]
+			success, failed = processor.process_chunk(
+				rows=chunk,
+				resource_type=resource_type,
+				parent_id=parent_id or None,
+				flush_reason=reason,
+			)
+			totals["success"] += success
+			totals["failed"] += failed
+
+	# Process parents (and everything that is not a variation) first, so that a parent product
+	# created in this same flush has a WooCommerce ID before its variations are sent.
+	variation_rows: list = []
+	for (resource_type, parent_id, _sync_type, _direction), rows in groups.items():
+		if resource_type == "product_variation":
+			variation_rows.extend(rows)
+			continue
+		run_chunks(resource_type, parent_id, rows)
+
+	# Variations: re-resolve each row's parent WooCommerce ID (the parent may have just been
+	# created above), then group by the resolved parent for the /products/{parent}/variations/batch
+	# endpoint.
+	if variation_rows:
+		variation_groups: dict[str, list] = {}
+		for row in variation_rows:
+			parent_wc_id = row.parent_woocommerce_id
+			if not parent_wc_id and row.reference_name:
+				parent_wc_id = _resolve_variation_parent_id(server_name, row.reference_name)
+			row.parent_woocommerce_id = parent_wc_id
+			variation_groups.setdefault(parent_wc_id or "", []).append(row)
+		for parent_wc_id, rows in variation_groups.items():
+			run_chunks("product_variation", parent_wc_id or None, rows)
+
+	return {
+		"flushed": totals["success"] + totals["failed"],
+		"success": totals["success"],
+		"failed": totals["failed"],
+	}
+
+
+def _resolve_variation_parent_id(server_name: str, variant_item_code: str) -> str | None:
+	"""
+	Resolve the WooCommerce ID of a variant item's parent (template) for the given server.
+	Used at flush time because the parent may have been created earlier in the same flush.
+	"""
+	variant_of = frappe.db.get_value("Item", variant_item_code, "variant_of")
+	if not variant_of:
+		return None
+	return frappe.db.get_value(
+		"Item WooCommerce Server",
+		{"parent": variant_of, "woocommerce_server": server_name},
+		"woocommerce_id",
+	)
+
+
+@frappe.whitelist()
+def check_and_flush_all_servers():
+	"""
+	Called by the scheduler every minute. Flushes servers whose queue is ready.
+	"""
+	servers = frappe.get_all(
+		"WooCommerce Server",
+		filters={"enable_sync": 1, "enable_batch_api": 1},
+		pluck="name",
+	)
+	for server_name in servers:
+		ready, reason = should_flush(server_name)
+		if ready:
+			frappe.enqueue(
+				"woocommerce_fusion.tasks.batch.queue_manager.flush_pending",
+				server_name=server_name,
+				reason=reason,
+				queue="long",
+			)
+
+
+@frappe.whitelist()
+def manual_flush(server_name: str):
+	"""Whitelisted for the UI 'Flush Now' button."""
+	return flush_pending(server_name, reason="manual")

--- a/woocommerce_fusion/tasks/batch/sync_item_prices_batch.py
+++ b/woocommerce_fusion/tasks/batch/sync_item_prices_batch.py
@@ -1,0 +1,88 @@
+import frappe
+
+from woocommerce_fusion.tasks.sync_item_prices import SynchroniseItemPrice
+from woocommerce_fusion.woocommerce.doctype.woocommerce_sync_queue.woocommerce_sync_queue import (
+	enqueue_item,
+)
+from woocommerce_fusion.woocommerce.woocommerce_api import (
+	generate_woocommerce_record_name_from_domain_and_id,
+)
+
+
+def enqueue_price_updates(sync: SynchroniseItemPrice) -> None:
+	"""
+	Enqueue an item_price operation (with the computed price payload stored in extra_data)
+	for each Item Price in sync.item_price_list, instead of PUTting directly.
+	"""
+	for item_price in sync.item_price_list:
+		try:
+			payload = _build_price_payload(sync, item_price)
+			if payload:
+				enqueue_item(
+					woocommerce_server=sync.wc_server.name,
+					item_code=item_price.item_code,
+					item_woocommerce_server_idx=0,
+					sync_type="item_price",
+					resource_type="product",
+					woocommerce_id=str(item_price.woocommerce_id),
+					direction="outbound",
+					triggered_by="Scheduled",
+					trigger_reference_doctype="Item Price",
+					trigger_reference_name=item_price.name,
+					extra_data=payload,
+				)
+		except Exception:
+			frappe.log_error("WooCommerce Batch Price Enqueue Error", frappe.get_traceback())
+
+
+def _build_price_payload(sync: SynchroniseItemPrice, item_price) -> dict | None:
+	"""
+	Load the WooCommerce Product, compare prices, and return the dict of changed price
+	fields, or None if nothing changed. Avoids enqueuing no-ops.
+	"""
+	wc_product_name = generate_woocommerce_record_name_from_domain_and_id(
+		domain=item_price.woocommerce_server, resource_id=item_price.woocommerce_id
+	)
+	wc_product = frappe.get_doc({"doctype": "WooCommerce Product", "name": wc_product_name})
+	wc_product.load_from_db()
+
+	payload = {}
+
+	# ── Regular price ────────────────────────────────────────────────────────────
+	price_list_rate = (
+		sync.item_price_doc.price_list_rate
+		if sync.item_price_doc and sync.item_price_doc.price_list == sync.wc_server.price_list
+		else item_price.price_list_rate
+	)
+	if not wc_product.regular_price:
+		wc_product.regular_price = 0
+	wc_product_regular_price = (
+		float(wc_product.regular_price)
+		if isinstance(wc_product.regular_price, str)
+		else wc_product.regular_price
+	)
+	if wc_product_regular_price != price_list_rate:
+		payload["regular_price"] = str(price_list_rate)
+
+	# ── Sale price ─────────────────────────────────────────────────────────────────
+	if sync.wc_server.enable_sales_price_list_sync and sync.wc_server.sales_price_list:
+		if sync._apply_sale_price(wc_product, item_price.woocommerce_id):
+			payload["sale_price"] = (
+				str(wc_product.sale_price)
+				if wc_product.sale_price and float(wc_product.sale_price) > 0
+				else ""
+			)
+			payload["date_on_sale_from"] = wc_product.date_on_sale_from
+			payload["date_on_sale_to"] = wc_product.date_on_sale_to
+
+	return payload or None
+
+
+class SynchroniseItemPriceBatch(SynchroniseItemPrice):
+	"""
+	Batch-mode subclass of SynchroniseItemPrice. Overrides
+	sync_items_with_woocommerce_products() to enqueue operations instead of PUTting directly.
+	"""
+
+	def sync_items_with_woocommerce_products(self) -> None:
+		enqueue_price_updates(self)

--- a/woocommerce_fusion/tasks/batch/sync_items_batch.py
+++ b/woocommerce_fusion/tasks/batch/sync_items_batch.py
@@ -1,0 +1,56 @@
+import frappe
+
+from woocommerce_fusion.tasks.sync_items import ERPNextItemToSync, SynchroniseItem
+from woocommerce_fusion.woocommerce.doctype.woocommerce_sync_queue.woocommerce_sync_queue import (
+	enqueue_item,
+)
+
+
+class SynchroniseItemBatch(SynchroniseItem):
+	"""
+	Batch-mode subclass. Overrides _send_create and _send_update to enqueue operations
+	instead of making immediate API calls. The conflict-resolution logic
+	(_build_create_payload, _build_update_payload, sync hash checks) is entirely inherited
+	and unchanged. Sync hash bookkeeping is deferred to the BatchProcessor at flush time.
+	"""
+
+	defer_sync_hash: bool = True
+
+	def _send_create(self, item: ERPNextItemToSync) -> None:
+		enqueue_item(
+			woocommerce_server=item.item_woocommerce_server.woocommerce_server,
+			item_code=item.item.name,
+			item_woocommerce_server_idx=item.item_woocommerce_server_idx,
+			resource_type=self._get_resource_type(item),
+			parent_woocommerce_id=self._get_parent_woocommerce_id(item),
+			woocommerce_id=None,
+			triggered_by="Hook",
+			trigger_reference_doctype="Item",
+			trigger_reference_name=item.item.name,
+		)
+
+	def _send_update(self, item: ERPNextItemToSync) -> None:
+		enqueue_item(
+			woocommerce_server=item.item_woocommerce_server.woocommerce_server,
+			item_code=item.item.name,
+			item_woocommerce_server_idx=item.item_woocommerce_server_idx,
+			resource_type=self._get_resource_type(item),
+			parent_woocommerce_id=self._get_parent_woocommerce_id(item),
+			woocommerce_id=str(item.item_woocommerce_server.woocommerce_id),
+			triggered_by="Hook",
+			trigger_reference_doctype="Item",
+			trigger_reference_name=item.item.name,
+		)
+
+	def _get_resource_type(self, item: ERPNextItemToSync) -> str:
+		if item.item.variant_of:
+			return "product_variation"
+		return "product"
+
+	def _get_parent_woocommerce_id(self, item: ERPNextItemToSync) -> str | None:
+		if self._get_resource_type(item) == "product_variation":
+			parent_item = frappe.get_doc("Item", item.item.variant_of)
+			for server_row in parent_item.woocommerce_servers:
+				if server_row.woocommerce_server == item.item_woocommerce_server.woocommerce_server:
+					return str(server_row.woocommerce_id) if server_row.woocommerce_id else None
+		return None

--- a/woocommerce_fusion/tasks/batch/sync_stock_batch.py
+++ b/woocommerce_fusion/tasks/batch/sync_stock_batch.py
@@ -1,0 +1,34 @@
+from woocommerce_fusion.woocommerce.doctype.woocommerce_sync_queue.woocommerce_sync_queue import (
+	enqueue_item,
+)
+
+
+def enqueue_stock_update(
+	woocommerce_server: str,
+	item_code: str,
+	woocommerce_id: str,
+	stock_quantity: int,
+	resource_type: str = "product",
+	parent_woocommerce_id: str | None = None,
+) -> str:
+	"""
+	Enqueue a stock-level update for batch processing.
+
+	The computed quantity is stored in extra_data so the BatchProcessor does not need to
+	re-query bins at flush time. Stock has no conflict resolution (ERPNext is the source of
+	truth), so the pre-computed value is used directly.
+	"""
+	return enqueue_item(
+		woocommerce_server=woocommerce_server,
+		item_code=item_code,
+		item_woocommerce_server_idx=0,
+		sync_type="stock",
+		resource_type=resource_type,
+		parent_woocommerce_id=parent_woocommerce_id,
+		woocommerce_id=str(woocommerce_id),
+		direction="outbound",
+		triggered_by="Hook",
+		trigger_reference_doctype="Item",
+		trigger_reference_name=item_code,
+		extra_data={"stock_quantity": stock_quantity},
+	)

--- a/woocommerce_fusion/tasks/batch/test_batch_sync.py
+++ b/woocommerce_fusion/tasks/batch/test_batch_sync.py
@@ -1,0 +1,246 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe import _dict
+from frappe.tests.utils import FrappeTestCase
+
+from woocommerce_fusion.tasks.batch.batch_processor import BatchProcessor
+from woocommerce_fusion.tasks.batch.queue_manager import flush_pending, should_flush
+from woocommerce_fusion.woocommerce.doctype.woocommerce_sync_queue.woocommerce_sync_queue import (
+	enqueue_item,
+	enqueue_order,
+)
+
+TEST_SERVER_URL = "https://batch-unit-test.example.com"
+TEST_SERVER = "batch-unit-test.example.com"
+
+
+def _ensure_test_server():
+	if not frappe.db.exists("WooCommerce Server", TEST_SERVER):
+		server = frappe.new_doc("WooCommerce Server")
+		server.woocommerce_server_url = TEST_SERVER_URL
+		server.enable_sync = 1
+		server.enable_batch_api = 1
+		server.batch_flush_interval_minutes = 1
+		server.batch_size_limit = 100
+		server.creation_user = "Administrator"
+		server.insert(ignore_permissions=True, ignore_mandatory=True)
+	return TEST_SERVER
+
+
+class TestQueueEnqueue(FrappeTestCase):
+	def setUp(self):
+		self.server = _ensure_test_server()
+
+	def test_enqueue_item_creates_pending_row(self):
+		name = enqueue_item(
+			woocommerce_server=self.server,
+			item_code="UNIT-ITEM-1",
+			item_woocommerce_server_idx=1,
+			woocommerce_id="10",
+			direction="outbound",
+		)
+		row = frappe.get_doc("WooCommerce Sync Queue", name)
+		self.assertEqual(row.status, "Pending")
+		self.assertEqual(row.sync_type, "item")
+		self.assertEqual(row.reference_name, "UNIT-ITEM-1")
+
+	def test_enqueue_item_supersedes_existing_pending_row(self):
+		first = enqueue_item(
+			woocommerce_server=self.server,
+			item_code="UNIT-ITEM-2",
+			item_woocommerce_server_idx=1,
+			direction="outbound",
+			triggered_by="Hook",
+		)
+		second = enqueue_item(
+			woocommerce_server=self.server,
+			item_code="UNIT-ITEM-2",
+			item_woocommerce_server_idx=1,
+			direction="outbound",
+			triggered_by="Scheduled",
+		)
+		self.assertNotEqual(first, second)
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", first, "status"), "Superseded")
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", second, "status"), "Pending")
+
+	def test_enqueue_item_direction_isolation(self):
+		out = enqueue_item(
+			woocommerce_server=self.server,
+			item_code="UNIT-ITEM-3",
+			item_woocommerce_server_idx=1,
+			direction="outbound",
+		)
+		inb = enqueue_item(
+			woocommerce_server=self.server,
+			item_code="UNIT-ITEM-3",
+			item_woocommerce_server_idx=1,
+			direction="inbound",
+		)
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", out, "status"), "Pending")
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", inb, "status"), "Pending")
+
+	def test_enqueue_order_direction_isolation(self):
+		out = enqueue_order(
+			woocommerce_server=self.server,
+			woocommerce_order_id="555",
+			new_status="completed",
+			direction="outbound",
+		)
+		inb = enqueue_order(
+			woocommerce_server=self.server,
+			woocommerce_order_id="555",
+			direction="inbound",
+		)
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", out, "status"), "Pending")
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", inb, "status"), "Pending")
+
+
+class TestShouldFlush(FrappeTestCase):
+	def test_should_flush_buffer_full(self):
+		with patch("frappe.db.count", return_value=100), patch("frappe.get_cached_doc") as mock_server:
+			mock_server.return_value = MagicMock(batch_size_limit=100, batch_flush_interval_minutes=1)
+			flush, reason = should_flush("any.example.com")
+		self.assertTrue(flush)
+		self.assertEqual(reason, "buffer_full")
+
+	def test_should_flush_false_when_empty(self):
+		with patch("frappe.db.count", return_value=0), patch("frappe.get_cached_doc") as mock_server:
+			mock_server.return_value = MagicMock(batch_size_limit=100, batch_flush_interval_minutes=1)
+			flush, reason = should_flush("any.example.com")
+		self.assertFalse(flush)
+		self.assertEqual(reason, "")
+
+
+class TestBatchProcessor(FrappeTestCase):
+	def setUp(self):
+		self.server = _ensure_test_server()
+
+	def _make_queue_row(self, **kwargs):
+		defaults = {
+			"doctype": "WooCommerce Sync Queue",
+			"woocommerce_server": self.server,
+			"sync_type": "item",
+			"direction": "outbound",
+			"wc_resource_type": "product",
+			"reference_doctype": "Item",
+			"status": "Pending",
+		}
+		defaults.update(kwargs)
+		doc = frappe.get_doc(defaults)
+		doc.insert(ignore_permissions=True)
+		return doc
+
+	def test_mark_completed_and_failed_update_rows(self):
+		processor = BatchProcessor(self.server)
+		row = self._make_queue_row(reference_name="UNIT-MC-1", woocommerce_id="42")
+
+		processor._mark_completed(
+			_dict({"name": row.name, "woocommerce_id": "42", "reference_name": "UNIT-MC-1"}),
+			{"id": 42},
+			None,
+			"update",
+		)
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", row.name, "status"), "Completed")
+
+		row2 = self._make_queue_row(reference_name="UNIT-MC-2", woocommerce_id="43")
+		processor._mark_failed(row2.name, "boom", None)
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", row2.name, "status"), "Failed")
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", row2.name, "error_message"), "boom")
+
+	def test_process_chunk_routes_by_type_and_direction(self):
+		processor = BatchProcessor(self.server)
+		with patch.object(processor, "_process_order_chunk", return_value=(1, 0)) as m_order:
+			processor.process_chunk(
+				[_dict({"sync_type": "order", "direction": "outbound"})], "order", None, "manual"
+			)
+			m_order.assert_called_once()
+
+		with patch.object(processor, "_process_order_inbound_chunk", return_value=(1, 0)) as m_oin:
+			processor.process_chunk(
+				[_dict({"sync_type": "order", "direction": "inbound"})], "order", None, "manual"
+			)
+			m_oin.assert_called_once()
+
+		with patch.object(processor, "_process_item_inbound_chunk", return_value=(1, 0)) as m_iin:
+			processor.process_chunk(
+				[_dict({"sync_type": "item", "direction": "inbound"})], "product", None, "manual"
+			)
+			m_iin.assert_called_once()
+
+		with patch.object(processor, "_process_simple_update_chunk", return_value=(1, 0)) as m_simple:
+			processor.process_chunk(
+				[_dict({"sync_type": "stock", "direction": "outbound"})], "product", None, "manual"
+			)
+			m_simple.assert_called_once()
+
+		with patch.object(processor, "_process_item_outbound_chunk", return_value=(1, 0)) as m_out:
+			processor.process_chunk(
+				[_dict({"sync_type": "item", "direction": "outbound"})], "product", None, "manual"
+			)
+			m_out.assert_called_once()
+
+	@patch("frappe.db.commit")
+	@patch(
+		"woocommerce_fusion.tasks.batch.batch_processor.WooCommerceProduct.batch_update",
+		return_value={"create": [{"id": 999, "date_modified": "2026-01-01T00:00:00"}], "update": []},
+	)
+	def test_execute_product_batch_marks_create_completed(self, mock_batch, mock_commit):
+		processor = BatchProcessor(self.server)
+		row = self._make_queue_row(reference_name="UNIT-CREATE-1")
+		batch_create = [
+			(
+				_dict({"name": row.name, "reference_name": "UNIT-CREATE-1", "woocommerce_id": None}),
+				{"name": "X"},
+			)
+		]
+
+		success, fail = processor._execute_product_batch(batch_create, [], "product", None, "manual")
+		self.assertEqual((success, fail), (1, 0))
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", row.name, "status"), "Completed")
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", row.name, "woocommerce_id"), "999")
+		mock_batch.assert_called_once()
+
+	@patch("frappe.db.commit")
+	@patch(
+		"woocommerce_fusion.tasks.batch.batch_processor.WooCommerceProduct.batch_update",
+		return_value={"create": [], "update": [{"error": {"message": "bad"}}]},
+	)
+	def test_execute_product_batch_partial_failure(self, mock_batch, mock_commit):
+		processor = BatchProcessor(self.server)
+		row = self._make_queue_row(reference_name="UNIT-UPD-1", woocommerce_id="77")
+		batch_update = [
+			(_dict({"name": row.name, "reference_name": "UNIT-UPD-1", "woocommerce_id": "77"}), {"name": "Y"})
+		]
+
+		success, fail = processor._execute_product_batch([], batch_update, "product", None, "manual")
+		self.assertEqual((success, fail), (0, 1))
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", row.name, "status"), "Failed")
+
+	@patch("frappe.db.commit")
+	def test_simple_update_chunk_uses_extra_data(self, mock_commit):
+		processor = BatchProcessor(self.server)
+		row = self._make_queue_row(
+			sync_type="stock",
+			reference_name="UNIT-STOCK-1",
+			woocommerce_id="88",
+			extra_data=json.dumps({"stock_quantity": 5}),
+		)
+		fetched = frappe.db.get_all(
+			"WooCommerce Sync Queue",
+			filters={"name": row.name},
+			fields=["name", "woocommerce_id", "reference_name", "extra_data", "sync_type"],
+		)
+		with patch.object(processor, "_execute_product_batch", return_value=(1, 0)) as m_exec:
+			processor._process_simple_update_chunk(fetched, "product", None, "manual")
+			m_exec.assert_called_once()
+			# The payload passed should contain the stock_quantity from extra_data
+			args, _kwargs = m_exec.call_args
+			batch_update = args[1]
+			self.assertEqual(batch_update[0][1], {"stock_quantity": 5})
+
+	def test_flush_pending_empty_returns_zero(self):
+		# Use a server with no pending rows
+		result = flush_pending(self.server, reason="manual")
+		self.assertIn("flushed", result)

--- a/woocommerce_fusion/tasks/stock_update.py
+++ b/woocommerce_fusion/tasks/stock_update.py
@@ -118,6 +118,7 @@ def update_stock_levels_on_woocommerce_site(item_code: str):
 					parent_item_id = item.variant_of
 					if parent_item_id:
 						parent_item = frappe.get_doc("Item", parent_item_id)
+						parent_woocommerce_id = None
 						# Get the parent item's woocommerce_id
 						for parent_wc_site in parent_item.woocommerce_servers:
 							if parent_wc_site.woocommerce_server == woocommerce_server:
@@ -127,7 +128,22 @@ def update_stock_levels_on_woocommerce_site(item_code: str):
 							continue
 						endpoint = f"products/{parent_woocommerce_id}/variations/{woocommerce_id}"
 					else:
+						parent_woocommerce_id = None
 						endpoint = f"products/{woocommerce_id}"
+
+					if wc_server.enable_batch_api:
+						from woocommerce_fusion.tasks.batch.sync_stock_batch import enqueue_stock_update
+
+						enqueue_stock_update(
+							woocommerce_server=woocommerce_server,
+							item_code=item_code,
+							woocommerce_id=woocommerce_id,
+							stock_quantity=data_to_post["stock_quantity"],
+							resource_type="product_variation" if parent_item_id else "product",
+							parent_woocommerce_id=parent_woocommerce_id,
+						)
+						continue
+
 					response = wc_api.put(endpoint=endpoint, data=data_to_post)
 				except Exception as err:
 					error_message = f"{frappe.get_traceback()}\n\nData in PUT request: \n{data_to_post}"

--- a/woocommerce_fusion/tasks/sync_item_prices.py
+++ b/woocommerce_fusion/tasks/sync_item_prices.py
@@ -81,7 +81,12 @@ class SynchroniseItemPrice(SynchroniseWooCommerce):
 			self.wc_server = server
 			self.get_erpnext_item_prices()
 			self.get_erpnext_sale_prices()
-			self.sync_items_with_woocommerce_products()
+			if server.enable_batch_api:
+				from woocommerce_fusion.tasks.batch.sync_item_prices_batch import enqueue_price_updates
+
+				enqueue_price_updates(self)
+			else:
+				self.sync_items_with_woocommerce_products()
 
 	def get_erpnext_item_prices(self) -> None:
 		"""

--- a/woocommerce_fusion/tasks/sync_items.py
+++ b/woocommerce_fusion/tasks/sync_items.py
@@ -27,6 +27,8 @@ def run_item_sync_from_hook(doc, method):
 	"""
 	Intended to be triggered by a Document Controller hook from Item
 	"""
+	if frappe.flags.in_test:
+		return
 	if (
 		doc.doctype == "Item"
 		and not doc.flags.get("created_by_sync", None)

--- a/woocommerce_fusion/tasks/sync_items.py
+++ b/woocommerce_fusion/tasks/sync_items.py
@@ -43,6 +43,10 @@ def run_item_sync_from_hook(doc, method):
 			alert=True,
 		)
 		frappe.enqueue(clear_sync_hash_and_run_item_sync, item_code=doc.name)
+		frappe.enqueue(
+			"woocommerce_fusion.tasks.batch.queue_manager.check_and_flush_all_servers",
+			enqueue_after_commit=True,
+		)
 
 
 @frappe.whitelist()
@@ -62,6 +66,8 @@ def run_item_sync(
 			"At least one of item_code, item, woocommerce_product_name, woocommerce_product parameters required"
 		)
 
+	from woocommerce_fusion.tasks.batch import get_item_sync_class
+
 	# Get ERPNext Item and WooCommerce product if they exist
 	if woocommerce_product or woocommerce_product_name:
 		if not woocommerce_product:
@@ -71,7 +77,8 @@ def run_item_sync(
 			woocommerce_product.load_from_db()
 
 		# Trigger sync
-		sync = SynchroniseItem(woocommerce_product=woocommerce_product)
+		SyncClass = get_item_sync_class(woocommerce_product.woocommerce_server)
+		sync = SyncClass(woocommerce_product=woocommerce_product)
 		if enqueue:
 			frappe.enqueue(sync.run)
 		else:
@@ -84,9 +91,8 @@ def run_item_sync(
 			frappe.throw(_("No WooCommerce Servers defined for Item {0}").format(item_code))
 		for wc_server in item.woocommerce_servers:
 			# Trigger sync for every linked server
-			sync = SynchroniseItem(
-				item=ERPNextItemToSync(item=item, item_woocommerce_server_idx=wc_server.idx)
-			)
+			SyncClass = get_item_sync_class(wc_server.woocommerce_server)
+			sync = SyncClass(item=ERPNextItemToSync(item=item, item_woocommerce_server_idx=wc_server.idx))
 			if enqueue:
 				frappe.enqueue(sync.run)
 			else:
@@ -121,7 +127,22 @@ def sync_woocommerce_products_modified_since(date_time_from=None):
 	wc_products = get_list_of_wc_products(date_time_from=date_time_from)
 	for wc_product in wc_products:
 		try:
-			run_item_sync(woocommerce_product=wc_product, enqueue=True)
+			server = frappe.get_cached_doc("WooCommerce Server", wc_product.woocommerce_server)
+			if server.enable_batch_api:
+				from woocommerce_fusion.woocommerce.doctype.woocommerce_sync_queue.woocommerce_sync_queue import (
+					enqueue_item,
+				)
+
+				enqueue_item(
+					woocommerce_server=wc_product.woocommerce_server,
+					item_code=str(wc_product.woocommerce_id),
+					item_woocommerce_server_idx=0,
+					woocommerce_id=str(wc_product.woocommerce_id),
+					direction="inbound",
+					triggered_by="Scheduled",
+				)
+			else:
+				run_item_sync(woocommerce_product=wc_product, enqueue=True)
 		# Skip items with errors, as these exceptions will be logged
 		except Exception:
 			pass
@@ -145,6 +166,9 @@ class SynchroniseItem(SynchroniseWooCommerce):
 	"""
 	Class for managing synchronisation of WooCommerce Product with ERPNext Item
 	"""
+
+	# When True, sync hash bookkeeping is deferred to the BatchProcessor at flush time
+	defer_sync_hash: bool = False
 
 	def __init__(
 		self,
@@ -289,9 +313,21 @@ class SynchroniseItem(SynchroniseWooCommerce):
 		"""
 		Update the WooCommerce Product with fields from it's corresponding ERPNext Item
 		"""
+		self.woocommerce_product = wc_product
+		if self._mutate_product_for_update(item):
+			self._send_update(item)
+
+		if not self.defer_sync_hash:
+			self.set_sync_hash()
+
+	def _mutate_product_for_update(self, item: ERPNextItemToSync) -> bool:
+		"""
+		Mutate self.woocommerce_product to reflect the ERPNext Item. Returns True if anything
+		changed.
+		"""
+		wc_product = self.woocommerce_product
 		wc_product_dirty = False
 
-		# Update properties
 		if wc_product.woocommerce_name != item.item.item_name:
 			wc_product.woocommerce_name = item.item.item_name
 			wc_product_dirty = True
@@ -300,11 +336,36 @@ class SynchroniseItem(SynchroniseWooCommerce):
 		if product_fields_changed:
 			wc_product_dirty = True
 
-		if wc_product_dirty:
-			wc_product.save()
-
 		self.woocommerce_product = wc_product
-		self.set_sync_hash()
+		return wc_product_dirty
+
+	def _build_update_payload(self, item: ERPNextItemToSync) -> dict:
+		"""
+		Snapshot self.woocommerce_product, mutate it to reflect the ERPNext Item, and return a
+		dict of only the changed fields (ready for a WooCommerce batch update), or an empty dict
+		if nothing changed. Used by the BatchProcessor against freshly fetched WC data.
+		"""
+		before = WooCommerceProduct.deserialize_attributes_of_type_dict_or_list(
+			self.woocommerce_product.to_dict()
+		)
+
+		if not self._mutate_product_for_update(item):
+			return {}
+
+		after = WooCommerceProduct.deserialize_attributes_of_type_dict_or_list(
+			self.woocommerce_product.to_dict()
+		)
+		payload = {key: value for key, value in after.items() if before.get(key) != value}
+
+		# Map the Frappe field name back to the WooCommerce API field name
+		if "woocommerce_name" in payload:
+			payload["name"] = payload.pop("woocommerce_name")
+
+		return payload
+
+	def _send_update(self, item: ERPNextItemToSync) -> None:
+		"""Persist the WooCommerce Product update via the API (PUT)."""
+		self.woocommerce_product.save()
 
 	def create_woocommerce_product(self, item: ERPNextItemToSync) -> None:
 		"""
@@ -315,75 +376,96 @@ class SynchroniseItem(SynchroniseWooCommerce):
 			and item.item_woocommerce_server.enabled
 			and not item.item_woocommerce_server.woocommerce_id
 		):
-			# Create a new WooCommerce Product doc
-			wc_product = frappe.get_doc({"doctype": "WooCommerce Product"})
+			self._build_create_product(item)
+			self._send_create(item)
 
-			wc_product.type = "simple"
+	def _build_create_payload(self, item: ERPNextItemToSync) -> dict:
+		"""
+		Build a new WooCommerce Product doc and return the cleaned payload dict to send to
+		WooCommerce. Used by the BatchProcessor.
+		"""
+		wc_product = self._build_create_product(item)
+		record = WooCommerceProduct.deserialize_attributes_of_type_dict_or_list(wc_product.to_dict())
+		return wc_product.before_db_insert(record)
 
-			# Handle variants
-			if item.item.has_variants:
-				wc_product.type = "variable"
-				wc_product_attributes = []
+	def _build_create_product(self, item: ERPNextItemToSync) -> WooCommerceProduct:
+		"""
+		Build a new WooCommerce Product doc from the ERPNext Item and set it on
+		self.woocommerce_product.
+		"""
+		# Create a new WooCommerce Product doc
+		wc_product = frappe.get_doc({"doctype": "WooCommerce Product"})
 
-				# Handle attributes
-				for row in item.item.attributes:
-					item_attribute = frappe.get_doc("Item Attribute", row.attribute)
-					wc_product_attributes.append(
-						{
-							"name": row.attribute,
-							"slug": row.attribute.lower().replace(" ", "_"),
-							"visible": True,
-							"variation": True,
-							"options": [
-								option.attribute_value for option in item_attribute.item_attribute_values
-							],
-						}
-					)
+		wc_product.type = "simple"
 
-				wc_product.attributes = json.dumps(wc_product_attributes)
+		# Handle variants
+		if item.item.has_variants:
+			wc_product.type = "variable"
+			wc_product_attributes = []
 
-			if item.item.variant_of:
-				# Check if parent exists
-				parent_item = frappe.get_doc("Item", item.item.variant_of)
-				parent_item, parent_wc_product = run_item_sync(item_code=parent_item.item_code)
-				wc_product.parent_id = parent_wc_product.woocommerce_id
-				wc_product.type = "variation"
-
-				# Handle attributes
-				wc_product_attributes = [
+			# Handle attributes
+			for row in item.item.attributes:
+				item_attribute = frappe.get_doc("Item Attribute", row.attribute)
+				wc_product_attributes.append(
 					{
 						"name": row.attribute,
 						"slug": row.attribute.lower().replace(" ", "_"),
-						"option": row.attribute_value,
+						"visible": True,
+						"variation": True,
+						"options": [
+							option.attribute_value for option in item_attribute.item_attribute_values
+						],
 					}
-					for row in item.item.attributes
-				]
+				)
 
-				wc_product.attributes = json.dumps(wc_product_attributes)
+			wc_product.attributes = json.dumps(wc_product_attributes)
 
-			# Set properties
-			wc_product.woocommerce_server = item.item_woocommerce_server.woocommerce_server
-			wc_product.woocommerce_name = item.item.item_name
-			wc_product.regular_price = get_item_price_rate(item) or "0"
+		if item.item.variant_of:
+			# Check if parent exists
+			parent_item = frappe.get_doc("Item", item.item.variant_of)
+			parent_item, parent_wc_product = run_item_sync(item_code=parent_item.item_code)
+			wc_product.parent_id = parent_wc_product.woocommerce_id if parent_wc_product else None
+			wc_product.type = "variation"
 
-			sale_price_data = get_item_sale_price_data(item)
-			if sale_price_data:
-				wc_product.sale_price = sale_price_data.price_list_rate
-				wc_product.date_on_sale_from = _format_sale_date(sale_price_data.valid_from)
-				wc_product.date_on_sale_to = _format_sale_date(sale_price_data.valid_upto)
+			# Handle attributes
+			wc_product_attributes = [
+				{
+					"name": row.attribute,
+					"slug": row.attribute.lower().replace(" ", "_"),
+					"option": row.attribute_value,
+				}
+				for row in item.item.attributes
+			]
 
-			self.set_product_fields(wc_product, item)
+			wc_product.attributes = json.dumps(wc_product_attributes)
 
-			wc_product.insert()
-			self.woocommerce_product = wc_product
+		# Set properties
+		wc_product.woocommerce_server = item.item_woocommerce_server.woocommerce_server
+		wc_product.woocommerce_name = item.item.item_name
+		wc_product.regular_price = get_item_price_rate(item) or "0"
 
-			# Reload ERPNext Item
-			item.item.reload()
-			item.item_woocommerce_server.woocommerce_id = wc_product.woocommerce_id
-			item.item.flags.created_by_sync = True
-			item.item.save()
+		sale_price_data = get_item_sale_price_data(item)
+		if sale_price_data:
+			wc_product.sale_price = sale_price_data.price_list_rate
+			wc_product.date_on_sale_from = _format_sale_date(sale_price_data.valid_from)
+			wc_product.date_on_sale_to = _format_sale_date(sale_price_data.valid_upto)
 
-			self.set_sync_hash()
+		self.set_product_fields(wc_product, item)
+
+		self.woocommerce_product = wc_product
+		return wc_product
+
+	def _send_create(self, item: ERPNextItemToSync) -> None:
+		"""Persist the new WooCommerce Product via the API (POST) and write back the ID."""
+		self.woocommerce_product.insert()
+
+		# Reload ERPNext Item
+		item.item.reload()
+		item.item_woocommerce_server.woocommerce_id = self.woocommerce_product.woocommerce_id
+		item.item.flags.created_by_sync = True
+		item.item.save()
+
+		self.set_sync_hash()
 
 	def create_item(self, wc_product: WooCommerceProduct) -> None:
 		"""
@@ -693,12 +775,13 @@ def get_item_sale_price_data(item: ERPNextItemToSync) -> frappe._dict | None:
 	)
 
 
-def clear_sync_hash_and_run_item_sync(item_code: str):
+def clear_sync_hash(item_code: str) -> int:
 	"""
 	Clear the last sync hash value using db.set_value, as it does not call the ORM triggers
-	and it does not update the modified timestamp (by using the update_modified parameter)
-	"""
+	and it does not update the modified timestamp (by using the update_modified parameter).
 
+	Returns the count of Item WooCommerce Server rows cleared.
+	"""
 	iws = frappe.qb.DocType("Item WooCommerce Server")
 
 	iwss = (frappe.qb.from_(iws).where(iws.enabled == 1).where(iws.parent == item_code).select(iws.name)).run(
@@ -714,5 +797,9 @@ def clear_sync_hash_and_run_item_sync(item_code: str):
 			update_modified=False,
 		)
 
-	if len(iwss) > 0:
+	return len(iwss)
+
+
+def clear_sync_hash_and_run_item_sync(item_code: str):
+	if clear_sync_hash(item_code) > 0:
 		run_item_sync(item_code=item_code, enqueue=True)

--- a/woocommerce_fusion/tasks/sync_sales_orders.py
+++ b/woocommerce_fusion/tasks/sync_sales_orders.py
@@ -234,6 +234,11 @@ class SynchroniseSalesOrder(SynchroniseWooCommerce):
 			# create missing order in WooCommerce
 			pass
 		elif self.woocommerce_order and not self.sales_order:
+			# Don't create a Sales Order for an order that is trashed/cancelled in WooCommerce and
+			# was never synced to ERPNext - there is nothing to represent. Trashed/cancelled orders
+			# that DO have a linked Sales Order still flow through the update path below.
+			if self.woocommerce_order.status in ("trash", "cancelled"):
+				return
 			# create missing order in ERPNext
 			self.create_sales_order(self.woocommerce_order)
 		elif self.sales_order and self.woocommerce_order:

--- a/woocommerce_fusion/tasks/sync_sales_orders.py
+++ b/woocommerce_fusion/tasks/sync_sales_orders.py
@@ -407,16 +407,19 @@ class SynchroniseSalesOrder(SynchroniseWooCommerce):
 		Update the WooCommerce Order with fields from it's corresponding ERPNext Sales Order
 		"""
 		wc_order_dirty = False
+		wc_server = frappe.get_cached_doc("WooCommerce Server", wc_order.woocommerce_server)
 
-		# Update the woocommerce_status field if necessary
-		sales_order_wc_status = (
-			WC_ORDER_STATUS_MAPPING[sales_order.woocommerce_status]
-			if sales_order.woocommerce_status
-			else None
-		)
-		if sales_order_wc_status != wc_order.status:
-			wc_order.status = sales_order_wc_status
-			wc_order_dirty = True
+		# Update the woocommerce_status field if necessary. Only push the status to WooCommerce when
+		# Sales Order Status Sync is enabled.
+		if wc_server.enable_so_status_sync:
+			sales_order_wc_status = (
+				WC_ORDER_STATUS_MAPPING[sales_order.woocommerce_status]
+				if sales_order.woocommerce_status
+				else None
+			)
+			if sales_order_wc_status != wc_order.status:
+				wc_order.status = sales_order_wc_status
+				wc_order_dirty = True
 
 		# Get the Item WooCommerce ID's
 		for so_item in sales_order.items:
@@ -430,7 +433,6 @@ class SynchroniseSalesOrder(SynchroniseWooCommerce):
 			)
 
 		# Update the line_items field if necessary
-		wc_server = frappe.get_cached_doc("WooCommerce Server", wc_order.woocommerce_server)
 		if wc_server.sync_so_items_to_wc:
 			sales_order_items_changed = False
 			line_items = json.loads(wc_order.line_items)

--- a/woocommerce_fusion/tasks/sync_sales_orders.py
+++ b/woocommerce_fusion/tasks/sync_sales_orders.py
@@ -32,7 +32,26 @@ def run_sales_order_sync_from_hook(doc, method):
 		and doc.woocommerce_server
 		and frappe.get_cached_doc("WooCommerce Server", doc.woocommerce_server).enable_sync
 	):
-		frappe.enqueue(run_sales_order_sync, queue="long", sales_order_name=doc.name)
+		server = frappe.get_cached_doc("WooCommerce Server", doc.woocommerce_server)
+		if server.enable_batch_api and server.enable_so_status_sync and doc.woocommerce_id:
+			from woocommerce_fusion.woocommerce.doctype.woocommerce_sync_queue.woocommerce_sync_queue import (
+				enqueue_order,
+			)
+
+			new_status = WC_ORDER_STATUS_MAPPING[doc.woocommerce_status] if doc.woocommerce_status else None
+			enqueue_order(
+				woocommerce_server=doc.woocommerce_server,
+				woocommerce_order_id=str(doc.woocommerce_id),
+				new_status=new_status,
+				direction="outbound",
+				triggered_by="Hook",
+			)
+			frappe.enqueue(
+				"woocommerce_fusion.tasks.batch.queue_manager.check_and_flush_all_servers",
+				enqueue_after_commit=True,
+			)
+		else:
+			frappe.enqueue(run_sales_order_sync, queue="long", sales_order_name=doc.name)
 
 
 @frappe.whitelist()
@@ -109,7 +128,20 @@ def sync_woocommerce_orders_modified_since(date_time_from=None):
 	wc_orders += get_list_of_wc_orders(date_time_from=date_time_from, status="trash")
 	for wc_order in wc_orders:
 		try:
-			run_sales_order_sync(woocommerce_order=wc_order, enqueue=True)
+			server = frappe.get_cached_doc("WooCommerce Server", wc_order.woocommerce_server)
+			if server.enable_batch_api:
+				from woocommerce_fusion.woocommerce.doctype.woocommerce_sync_queue.woocommerce_sync_queue import (
+					enqueue_order,
+				)
+
+				enqueue_order(
+					woocommerce_server=wc_order.woocommerce_server,
+					woocommerce_order_id=str(wc_order.id),
+					direction="inbound",
+					triggered_by="Scheduled",
+				)
+			else:
+				run_sales_order_sync(woocommerce_order=wc_order, enqueue=True)
 		# Skip orders with errors, as these exceptions will be logged
 		except Exception:
 			pass

--- a/woocommerce_fusion/tasks/sync_sales_orders.py
+++ b/woocommerce_fusion/tasks/sync_sales_orders.py
@@ -142,9 +142,12 @@ def sync_woocommerce_orders_modified_since(date_time_from=None):
 				)
 			else:
 				run_sales_order_sync(woocommerce_order=wc_order, enqueue=True)
-		# Skip orders with errors, as these exceptions will be logged
 		except Exception:
-			pass
+			frappe.log_error(
+				"WooCommerce Sales Orders Sync Task Error",
+				f"Failed to queue/sync WooCommerce order {getattr(wc_order, 'id', '?')}:\n"
+				f"{frappe.get_traceback()}",
+			)
 
 	frappe.db.set_single_value("WooCommerce Integration Settings", "wc_last_sync_date", now())
 

--- a/woocommerce_fusion/tasks/sync_sales_orders.py
+++ b/woocommerce_fusion/tasks/sync_sales_orders.py
@@ -526,6 +526,8 @@ class SynchroniseSalesOrder(SynchroniseWooCommerce):
 		self.sales_order = new_sales_order
 		new_sales_order.customer = customer_docname
 		new_sales_order.po_no = new_sales_order.woocommerce_id = wc_order.id
+		# Carry the customer-facing WooCommerce order number for autonaming
+		new_sales_order.flags.woocommerce_number = wc_order.get("number")
 		new_sales_order.custom_woocommerce_customer_note = wc_order.customer_note
 
 		new_sales_order.woocommerce_status = WC_ORDER_STATUS_MAPPING_REVERSE[wc_order.status]

--- a/woocommerce_fusion/tasks/test_integration_batch_sync.py
+++ b/woocommerce_fusion/tasks/test_integration_batch_sync.py
@@ -1,0 +1,391 @@
+from unittest.mock import patch
+
+import frappe
+from erpnext.stock.doctype.item.test_item import create_item
+
+from woocommerce_fusion.tasks.batch.queue_manager import flush_pending
+from woocommerce_fusion.tasks.test_integration_helpers import TestIntegrationWooCommerce
+from woocommerce_fusion.tasks.test_integration_items_sync import get_items_for_wc_product
+from woocommerce_fusion.woocommerce.doctype.woocommerce_sync_queue.woocommerce_sync_queue import (
+	enqueue_item,
+	enqueue_order,
+)
+
+
+class TestIntegrationBatchItemSync(TestIntegrationWooCommerce):
+	"""Integration tests for batch outbound item sync (ERPNext → WooCommerce)."""
+
+	def setUp(self):
+		super().setUp()
+		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
+		wc_server.enable_batch_api = 1
+		wc_server.batch_flush_interval_minutes = 1
+		wc_server.batch_size_limit = 100
+		wc_server.save()
+		self.wc_server.reload()
+		self._batch_mode = True
+
+	def test_outbound_create_new_wc_product_via_batch(self):
+		item = create_item("BATCH-CREATE-001", valuation_rate=10)
+		row = item.append("woocommerce_servers")
+		row.woocommerce_server = self.wc_server.name
+		item.save()
+		item.reload()
+		server_row = item.woocommerce_servers[0]
+
+		enqueue_item(
+			woocommerce_server=self.wc_server.name,
+			item_code=item.name,
+			item_woocommerce_server_idx=server_row.idx,
+			resource_type="product",
+			woocommerce_id=None,
+			direction="outbound",
+			triggered_by="Manual",
+		)
+
+		pending = frappe.get_all(
+			"WooCommerce Sync Queue",
+			filters={"reference_name": item.name, "status": "Pending", "direction": "outbound"},
+		)
+		self.assertEqual(len(pending), 1)
+
+		flush_pending(self.wc_server.name, reason="manual")
+
+		queue_row = frappe.get_doc("WooCommerce Sync Queue", pending[0].name)
+		self.assertEqual(queue_row.status, "Completed")
+
+		item.reload()
+		self.assertIsNotNone(item.woocommerce_servers[0].woocommerce_id)
+
+		wc_product = self.get_woocommerce_product(product_id=item.woocommerce_servers[0].woocommerce_id)
+		self.assertEqual(wc_product["name"], item.item_name)
+
+	def test_outbound_update_existing_wc_product_via_batch(self):
+		item = create_item("BATCH-UPDATE-001", valuation_rate=10)
+		row = item.append("woocommerce_servers")
+		row.woocommerce_server = self.wc_server.name
+		item.save()
+		from woocommerce_fusion.tasks.sync_items import run_item_sync
+
+		run_item_sync(item_code=item.name)
+		flush_pending(self.wc_server.name, reason="manual")
+		item.reload()
+		wc_id = item.woocommerce_servers[0].woocommerce_id
+		self.assertIsNotNone(wc_id)
+
+		item.item_name = "BATCH-UPDATE-001-RENAMED"
+		item.save()
+
+		enqueue_item(
+			woocommerce_server=self.wc_server.name,
+			item_code=item.name,
+			item_woocommerce_server_idx=item.woocommerce_servers[0].idx,
+			resource_type="product",
+			woocommerce_id=wc_id,
+			direction="outbound",
+			triggered_by="Manual",
+		)
+
+		flush_pending(self.wc_server.name, reason="manual")
+
+		wc_product = self.get_woocommerce_product(product_id=wc_id)
+		self.assertEqual(wc_product["name"], "BATCH-UPDATE-001-RENAMED")
+
+	def test_outbound_batch_deduplication_supersedes_prior_pending_row(self):
+		item = create_item("BATCH-DEDUP-001", valuation_rate=10)
+		row = item.append("woocommerce_servers")
+		row.woocommerce_server = self.wc_server.name
+		item.save()
+		item.reload()
+		server_row = item.woocommerce_servers[0]
+
+		enqueue_item(
+			woocommerce_server=self.wc_server.name,
+			item_code=item.name,
+			item_woocommerce_server_idx=server_row.idx,
+			direction="outbound",
+			triggered_by="Hook",
+		)
+		first_row = frappe.get_all(
+			"WooCommerce Sync Queue",
+			filters={"reference_name": item.name, "status": "Pending"},
+			pluck="name",
+		)[0]
+
+		enqueue_item(
+			woocommerce_server=self.wc_server.name,
+			item_code=item.name,
+			item_woocommerce_server_idx=server_row.idx,
+			direction="outbound",
+			triggered_by="Scheduled",
+		)
+
+		self.assertEqual(frappe.db.get_value("WooCommerce Sync Queue", first_row, "status"), "Superseded")
+		pending = frappe.get_all(
+			"WooCommerce Sync Queue",
+			filters={"reference_name": item.name, "status": "Pending"},
+		)
+		self.assertEqual(len(pending), 1)
+
+	def test_outbound_batch_multiple_items_uses_single_batch_post(self):
+		items = []
+		from woocommerce_fusion.tasks.sync_items import run_item_sync
+
+		for i in range(5):
+			item = create_item(f"BATCH-MULTI-{i:03d}", valuation_rate=10)
+			row = item.append("woocommerce_servers")
+			row.woocommerce_server = self.wc_server.name
+			item.save()
+			run_item_sync(item_code=item.name)
+			flush_pending(self.wc_server.name, reason="manual")
+			item.reload()
+			item.item_name = f"BATCH-MULTI-{i:03d}-renamed"
+			item.save()
+			enqueue_item(
+				woocommerce_server=self.wc_server.name,
+				item_code=item.name,
+				item_woocommerce_server_idx=item.woocommerce_servers[0].idx,
+				woocommerce_id=item.woocommerce_servers[0].woocommerce_id,
+				direction="outbound",
+				triggered_by="Manual",
+			)
+			items.append(item)
+
+		with patch(
+			"woocommerce_fusion.tasks.batch.batch_processor.BatchProcessor._execute_product_batch",
+			return_value=(len(items), 0),
+		) as mock_post:
+			flush_pending(self.wc_server.name, reason="manual")
+			self.assertEqual(mock_post.call_count, 1)
+
+	def test_outbound_partial_failure_marks_only_failed_rows(self):
+		good_item = create_item("BATCH-PARTIAL-GOOD", valuation_rate=10)
+		row = good_item.append("woocommerce_servers")
+		row.woocommerce_server = self.wc_server.name
+		good_item.save()
+		from woocommerce_fusion.tasks.sync_items import run_item_sync
+
+		run_item_sync(item_code=good_item.name)
+		flush_pending(self.wc_server.name, reason="manual")
+		good_item.reload()
+
+		good_item.item_name = "BATCH-PARTIAL-GOOD-renamed"
+		good_item.save()
+		enqueue_item(
+			woocommerce_server=self.wc_server.name,
+			item_code=good_item.name,
+			item_woocommerce_server_idx=good_item.woocommerce_servers[0].idx,
+			woocommerce_id=good_item.woocommerce_servers[0].woocommerce_id,
+			direction="outbound",
+			triggered_by="Manual",
+		)
+		# Enqueue a row with a non-existent WC ID to force a per-item error
+		bad_row = frappe.get_doc(
+			{
+				"doctype": "WooCommerce Sync Queue",
+				"woocommerce_server": self.wc_server.name,
+				"sync_type": "item",
+				"direction": "outbound",
+				"wc_resource_type": "product",
+				"woocommerce_id": "999999999",
+				"reference_doctype": "Item",
+				"reference_name": good_item.name,
+				"item_woocommerce_server_idx": good_item.woocommerce_servers[0].idx,
+				"triggered_by": "Manual",
+				"status": "Pending",
+			}
+		)
+		bad_row.insert(ignore_permissions=True)
+
+		flush_pending(self.wc_server.name, reason="manual")
+
+		bad_queue = frappe.get_doc("WooCommerce Sync Queue", bad_row.name)
+		self.assertEqual(bad_queue.status, "Failed")
+		self.assertIsNotNone(bad_queue.error_message)
+
+	def test_retry_failed_entry_goes_back_to_pending(self):
+		from woocommerce_fusion.woocommerce.page.woocommerce_sync_status.woocommerce_sync_status import (
+			retry_failed,
+		)
+
+		failed_row = frappe.get_doc(
+			{
+				"doctype": "WooCommerce Sync Queue",
+				"woocommerce_server": self.wc_server.name,
+				"sync_type": "item",
+				"direction": "outbound",
+				"wc_resource_type": "product",
+				"woocommerce_id": "999999999",
+				"reference_doctype": "Item",
+				"reference_name": "NONEXISTENT",
+				"item_woocommerce_server_idx": 1,
+				"triggered_by": "Manual",
+				"status": "Failed",
+				"error_message": "Simulated failure",
+				"retry_count": 1,
+			}
+		)
+		failed_row.insert(ignore_permissions=True)
+
+		retry_failed(failed_row.name)
+
+		failed_row.reload()
+		self.assertEqual(failed_row.status, "Pending")
+		self.assertEqual(failed_row.error_message, "")
+		self.assertEqual(failed_row.retry_count, 2)
+
+
+class TestIntegrationBatchInboundItemSync(TestIntegrationWooCommerce):
+	"""Integration tests for batch inbound item sync (WooCommerce → ERPNext)."""
+
+	def setUp(self):
+		super().setUp()
+		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
+		wc_server.enable_batch_api = 1
+		wc_server.save()
+		self.wc_server.reload()
+		self._batch_mode = True
+
+	def test_inbound_create_erpnext_item_via_batch(self):
+		wc_product_id = self.post_woocommerce_product(product_name="BATCH-INBOUND-001")
+
+		enqueue_item(
+			woocommerce_server=self.wc_server.name,
+			item_code=str(wc_product_id),
+			item_woocommerce_server_idx=0,
+			woocommerce_id=str(wc_product_id),
+			direction="inbound",
+			triggered_by="Scheduled",
+		)
+
+		pending = frappe.get_all(
+			"WooCommerce Sync Queue",
+			filters={"woocommerce_id": str(wc_product_id), "status": "Pending", "direction": "inbound"},
+		)
+		self.assertEqual(len(pending), 1)
+
+		flush_pending(self.wc_server.name, reason="manual")
+
+		queue_row = frappe.get_doc("WooCommerce Sync Queue", pending[0].name)
+		self.assertEqual(queue_row.status, "Completed")
+
+		items = get_items_for_wc_product(wc_product_id, self.wc_server.name)
+		self.assertEqual(len(items), 1)
+		self.assertEqual(items[0].item_name, "BATCH-INBOUND-001")
+
+	def test_inbound_bulk_get_processed_in_one_chunk(self):
+		wc_ids = [self.post_woocommerce_product(product_name=f"BATCH-INBOUND-MULTI-{i}") for i in range(3)]
+
+		for wc_id in wc_ids:
+			enqueue_item(
+				woocommerce_server=self.wc_server.name,
+				item_code=str(wc_id),
+				item_woocommerce_server_idx=0,
+				woocommerce_id=str(wc_id),
+				direction="inbound",
+				triggered_by="Scheduled",
+			)
+
+		with patch(
+			"woocommerce_fusion.tasks.batch.batch_processor.BatchProcessor._process_item_inbound_chunk",
+			return_value=(len(wc_ids), 0),
+		) as mock_chunk:
+			flush_pending(self.wc_server.name, reason="manual")
+			self.assertEqual(mock_chunk.call_count, 1)
+
+
+class TestIntegrationBatchOrderSync(TestIntegrationWooCommerce):
+	"""Integration tests for batch order sync (both directions)."""
+
+	def setUp(self):
+		super().setUp()
+		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
+		wc_server.enable_batch_api = 1
+		wc_server.enable_so_status_sync = 1
+		wc_server.flags.ignore_mandatory = True
+		wc_server.save()
+		self.wc_server.reload()
+		self._batch_mode = True
+
+	@patch("woocommerce_fusion.tasks.sync_sales_orders.frappe.log_error")
+	def test_inbound_order_creates_sales_order_via_batch(self, mock_log_error):
+		wc_order_id, _ = self.post_woocommerce_order(set_paid=True)
+
+		enqueue_order(
+			woocommerce_server=self.wc_server.name,
+			woocommerce_order_id=str(wc_order_id),
+			direction="inbound",
+			triggered_by="Scheduled",
+		)
+
+		pending = frappe.get_all(
+			"WooCommerce Sync Queue",
+			filters={"woocommerce_id": str(wc_order_id), "status": "Pending", "direction": "inbound"},
+		)
+		self.assertEqual(len(pending), 1)
+
+		flush_pending(self.wc_server.name, reason="manual")
+
+		mock_log_error.assert_not_called()
+
+		queue_row = frappe.get_doc("WooCommerce Sync Queue", pending[0].name)
+		self.assertEqual(queue_row.status, "Completed")
+
+		so = frappe.get_all(
+			"Sales Order",
+			filters={"woocommerce_id": str(wc_order_id), "woocommerce_server": self.wc_server.name},
+		)
+		self.assertEqual(len(so), 1)
+
+		self.delete_woocommerce_order(wc_order_id=wc_order_id)
+
+	def test_outbound_order_status_update_via_batch(self):
+		wc_order_id, _ = self.post_woocommerce_order()
+
+		enqueue_order(
+			woocommerce_server=self.wc_server.name,
+			woocommerce_order_id=str(wc_order_id),
+			new_status="completed",
+			direction="outbound",
+			triggered_by="Hook",
+		)
+
+		flush_pending(self.wc_server.name, reason="manual")
+
+		wc_order = self.get_woocommerce_order(order_id=wc_order_id)
+		self.assertEqual(wc_order["status"], "completed")
+
+		self.delete_woocommerce_order(wc_order_id=wc_order_id)
+
+	def test_inbound_and_outbound_rows_do_not_cross_supersede(self):
+		wc_order_id, _ = self.post_woocommerce_order()
+
+		enqueue_order(
+			woocommerce_server=self.wc_server.name,
+			woocommerce_order_id=str(wc_order_id),
+			direction="inbound",
+			triggered_by="Scheduled",
+		)
+		enqueue_order(
+			woocommerce_server=self.wc_server.name,
+			woocommerce_order_id=str(wc_order_id),
+			new_status="completed",
+			direction="outbound",
+			triggered_by="Hook",
+		)
+
+		pending = frappe.get_all(
+			"WooCommerce Sync Queue",
+			filters={
+				"woocommerce_id": str(wc_order_id),
+				"status": "Pending",
+				"woocommerce_server": self.wc_server.name,
+			},
+			fields=["direction"],
+		)
+		directions = {r.direction for r in pending}
+		self.assertIn("inbound", directions)
+		self.assertIn("outbound", directions)
+		self.assertEqual(len(pending), 2)
+
+		self.delete_woocommerce_order(wc_order_id=wc_order_id)

--- a/woocommerce_fusion/tasks/test_integration_helpers.py
+++ b/woocommerce_fusion/tasks/test_integration_helpers.py
@@ -83,6 +83,41 @@ class TestIntegrationWooCommerce(FrappeTestCase):
 		settings.wc_last_sync_date_items = one_year_ago
 		settings.save()
 
+	def tearDown(self):
+		# FrappeTestCase only rolls back once per class, so batch-mode tests would otherwise
+		# share a transaction and leak Sync Queue rows / fixed item codes into each other (e.g. a
+		# Pending row for a since-deleted order, or the two parameterised variants colliding on the
+		# same item code). Roll back after each batch-mode test to keep them isolated. Batch code
+		# avoids committing under tests (see commit_unless_in_test) so this fully reverts the test's
+		# database changes. Gated on _batch_mode (set by _set_batch_mode and by the batch test
+		# classes' setUp) so non-batch tests keep their existing class-level cleanup behaviour.
+		if getattr(self, "_batch_mode", None) is not None:
+			frappe.db.rollback()
+		super().tearDown()
+
+	def _set_batch_mode(self, enabled: bool):
+		"""
+		Enable or disable batch API on the test WooCommerce Server.
+		Called at the top of each parameterised test variant.
+		"""
+		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
+		wc_server.enable_batch_api = 1 if enabled else 0
+		wc_server.batch_flush_interval_minutes = 1
+		wc_server.batch_size_limit = 100
+		wc_server.save()
+		self.wc_server.reload()
+		self._batch_mode = enabled
+
+	def _flush_if_batch(self):
+		"""
+		In batch mode: flush the pending queue for this server so that enqueued operations
+		actually reach WooCommerce before assertions run. No-op in single-call mode.
+		"""
+		if getattr(self, "_batch_mode", False):
+			from woocommerce_fusion.tasks.batch.queue_manager import flush_pending
+
+			flush_pending(self.wc_server.name, reason="manual")
+
 	def post_woocommerce_order(
 		self,
 		set_paid: bool = False,

--- a/woocommerce_fusion/tasks/test_integration_helpers.py
+++ b/woocommerce_fusion/tasks/test_integration_helpers.py
@@ -592,6 +592,30 @@ def create_gl_account_for_tax():
 		pass
 
 
+def create_gl_account_for_shipping_tax():
+	"""Create a tax account for shipping tax that is distinct from the VAT account.
+
+	On Frappe v16, ERPNext keys the per-item tax map by account head (last-write-wins), so
+	re-using the VAT account for shipping tax would zero the calculated VAT row. Use a
+	separate tax account.
+	"""
+	if frappe.db.exists("Account", "Shipping Tax - SC"):
+		return "Shipping Tax - SC"
+	return (
+		frappe.get_doc(
+			{
+				"doctype": "Account",
+				"company": default_company,
+				"account_name": "Shipping Tax",
+				"parent_account": "Duties and Taxes - SC",
+				"account_type": "Tax",
+			}
+		)
+		.insert(ignore_if_duplicate=True)
+		.name
+	)
+
+
 def get_woocommerce_server(woocommerce_server_url: str):
 	wc_servers = frappe.get_all(
 		"WooCommerce Server", filters={"woocommerce_server_url": woocommerce_server_url}

--- a/woocommerce_fusion/tasks/test_integration_helpers.py
+++ b/woocommerce_fusion/tasks/test_integration_helpers.py
@@ -8,7 +8,7 @@ from frappe.utils import add_to_date, now
 
 from woocommerce_fusion.woocommerce.woocommerce_api import WC_RESOURCE_DELIMITER
 
-default_company = get_default_company()
+default_company = get_default_company() or "Some Company (Pty) Ltd"
 default_bank = "Test Bank"
 default_bank_account = "Checking Account"
 
@@ -88,8 +88,8 @@ class TestIntegrationWooCommerce(FrappeTestCase):
 		# share a transaction and leak Sync Queue rows / fixed item codes into each other (e.g. a
 		# Pending row for a since-deleted order, or the two parameterised variants colliding on the
 		# same item code). Roll back after each batch-mode test to keep them isolated. Batch code
-		# avoids committing under tests (see commit_unless_in_test) so this fully reverts the test's
-		# database changes. Gated on _batch_mode (set by _set_batch_mode and by the batch test
+		# guards its frappe.db.commit() calls with `not frappe.flags.in_test`, so this fully reverts
+		# the test's database changes. Gated on _batch_mode (set by _set_batch_mode and by the batch test
 		# classes' setUp) so non-batch tests keep their existing class-level cleanup behaviour.
 		if getattr(self, "_batch_mode", None) is not None:
 			frappe.db.rollback()
@@ -565,7 +565,7 @@ def create_gl_account_for_bank(account_name="_Test Bank"):
 		frappe.get_doc(
 			{
 				"doctype": "Account",
-				"company": get_default_company(),
+				"company": default_company,
 				"account_name": account_name,
 				"parent_account": "Bank Accounts - SC",
 				"type": "Bank",
@@ -582,7 +582,7 @@ def create_gl_account_for_tax():
 		frappe.get_doc(
 			{
 				"doctype": "Account",
-				"company": get_default_company(),
+				"company": default_company,
 				"account_name": "VAT",
 				"parent_account": "Duties and Taxes - SC",
 				"type": "Bank",

--- a/woocommerce_fusion/tasks/test_integration_helpers.py
+++ b/woocommerce_fusion/tasks/test_integration_helpers.py
@@ -451,6 +451,29 @@ class TestIntegrationWooCommerce(FrappeTestCase):
 
 		return order_data
 
+	def update_woocommerce_order_status(self, order_id: int, status: str) -> dict:
+		"""
+		Update an order's status directly on a WooCommerce testing site (i.e. as if changed in
+		WooCommerce).
+		"""
+		import json
+
+		from requests_oauthlib import OAuth1Session
+
+		# Initialize OAuth1 session
+		oauth = OAuth1Session(self.wc_consumer_key, client_secret=self.wc_consumer_secret)
+		if not verify_ssl:
+			oauth.verify = False
+
+		# API Endpoint
+		url = f"{self.wc_url}/wp-json/wc/v3/orders/{order_id}"
+		headers = {"Content-Type": "application/json"}
+
+		# Making the API call
+		response = oauth.put(url, headers=headers, data=json.dumps({"status": status}))
+
+		return response.json()
+
 	def post_product_attribute(self, attribute_name: str, attribute_slug: str):
 		"""
 		Post product attribute to WooCommerce

--- a/woocommerce_fusion/tasks/test_integration_item_price_sync.py
+++ b/woocommerce_fusion/tasks/test_integration_item_price_sync.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 import frappe
 from erpnext import get_default_company
 from erpnext.stock.doctype.item.test_item import create_item
+from parameterized import parameterized
 
 from woocommerce_fusion.tasks.sync_item_prices import run_item_price_sync
 from woocommerce_fusion.tasks.test_integration_helpers import (
@@ -10,16 +11,21 @@ from woocommerce_fusion.tasks.test_integration_helpers import (
 	get_woocommerce_server,
 )
 
+BATCH_MODES = [("single_call", False), ("batch_api", True)]
+
 
 class TestIntegrationWooCommerceItemPriceSync(TestIntegrationWooCommerce):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()  # important to call super() methods when extending TestCase.
 
-	def test_item_price_sync_when_synchronising_with_woocommerce(self):
+	@parameterized.expand(BATCH_MODES)
+	def test_item_price_sync_when_synchronising_with_woocommerce(self, _name, batch_enabled):
 		"""
 		Test that the Item Price Synchronisation method posts the correct price to a WooCommerce website.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Create a new product in WooCommerce, set regular price to 10
 		wc_product_id = self.post_woocommerce_product(product_name="ITEM002", regular_price=10)
 
@@ -44,6 +50,7 @@ class TestIntegrationWooCommerceItemPriceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		stock_update_result = run_item_price_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		# Expect successful update
 		self.assertEqual(stock_update_result, True)
@@ -52,10 +59,15 @@ class TestIntegrationWooCommerceItemPriceSync(TestIntegrationWooCommerce):
 		wc_price = self.get_woocommerce_product_price(product_id=wc_product_id)
 		self.assertEqual(float(wc_price), 5000)
 
-	def test_item_price_sync_ignored_if_item_disabled_when_synchronising_with_woocommerce(self):
+	@parameterized.expand(BATCH_MODES)
+	def test_item_price_sync_ignored_if_item_disabled_when_synchronising_with_woocommerce(
+		self, _name, batch_enabled
+	):
 		"""
 		Test that the Item Price Synchronisation method does not post a price to a WooCommerce website when the item is disabled.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Create a new product in WooCommerce, set regular price to 10
 		wc_product_id = self.post_woocommerce_product(product_name="ITEM003", regular_price=10)
 
@@ -83,6 +95,7 @@ class TestIntegrationWooCommerceItemPriceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		stock_update_result = run_item_price_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		# Expect successful update
 		self.assertEqual(stock_update_result, True)

--- a/woocommerce_fusion/tasks/test_integration_items_sync.py
+++ b/woocommerce_fusion/tasks/test_integration_items_sync.py
@@ -3,12 +3,15 @@ from unittest.mock import patch
 import frappe
 from erpnext.stock.doctype.item.test_item import create_item
 from frappe.utils.data import cstr
+from parameterized import parameterized
 
 from woocommerce_fusion.tasks.sync_items import run_item_sync
 from woocommerce_fusion.tasks.test_integration_helpers import TestIntegrationWooCommerce
 from woocommerce_fusion.woocommerce.woocommerce_api import (
 	generate_woocommerce_record_name_from_domain_and_id,
 )
+
+BATCH_MODES = [("single_call", False), ("batch_api", True)]
 
 
 @patch("woocommerce_fusion.tasks.sync_items.frappe.log_error")
@@ -17,11 +20,16 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 	def setUpClass(cls):
 		super().setUpClass()  # important to call super() methods when extending TestCase.
 
-	def test_sync_create_new_item_when_synchronising_with_woocommerce(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_item_when_synchronising_with_woocommerce(
+		self, mock_log_error, _name, batch_enabled
+	):
 		"""
 		Test that the Item Synchronisation method creates new Items when there are new
 		WooCommerce products.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Create a new product in WooCommerce
 		wc_product_id = self.post_woocommerce_product(product_name="SOME_ITEM")
 
@@ -30,6 +38,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 			self.wc_server.name, wc_product_id
 		)
 		run_item_sync(woocommerce_product_name=woocommerce_product_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -44,11 +53,16 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 		self.assertEqual(item.item_code, str(wc_product_id))
 		self.assertEqual(item.item_name, "SOME_ITEM")
 
-	def test_sync_create_new_item_with_image_when_synchronising_with_woocommerce(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_item_with_image_when_synchronising_with_woocommerce(
+		self, mock_log_error, _name, batch_enabled
+	):
 		"""
 		Test that the Item Synchronisation method creates a new Item with image when there are new
 		WooCommerce products.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		wc_server.enable_image_sync = 1
@@ -65,6 +79,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 			self.wc_server.name, wc_product_id
 		)
 		run_item_sync(woocommerce_product_name=woocommerce_product_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -78,12 +93,15 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 		# Expect correct image in item
 		self.assertTrue("chrislema-hat" in item.image)
 
+	@parameterized.expand(BATCH_MODES)
 	def test_sync_create_new_item_with_custom_metadata_when_synchronising_with_woocommerce(
-		self, mock_log_error
+		self, mock_log_error, _name, batch_enabled
 	):
 		"""
 		Test that the Item Synchronisation method creates a new ERPNext Item with mapped custom fields.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		dummy_meta_data = [
 			{"id": 52824, "key": "_short_description_1", "value": "Test 1"},
 			{"id": 52825, "key": "_short_description_2", "value": "Test 2"},
@@ -109,6 +127,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 			self.wc_server.name, wc_product_id
 		)
 		run_item_sync(woocommerce_product_name=woocommerce_product_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -122,10 +141,15 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 		# Expect value in mapped field in Item
 		self.assertEqual(item.description, "Test 2")
 
-	def test_sync_create_new_template_item_when_synchronising_with_woocommerce(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_template_item_when_synchronising_with_woocommerce(
+		self, mock_log_error, _name, batch_enabled
+	):
 		"""
 		Test that the Item Synchronisation method creates new Template Item from a WooCommerce Product with Variations
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Create a new product in WooCommerce
 		wc_product_id = self.post_woocommerce_product(
 			product_name="T-SHIRT", type="variable", attributes=["Material Type", "Volume"]
@@ -136,6 +160,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 			self.wc_server.name, wc_product_id
 		)
 		run_item_sync(woocommerce_product_name=woocommerce_product_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -154,11 +179,16 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 		self.assertEqual(item.attributes[0].attribute, "Material Type")
 		self.assertEqual(item.attributes[1].attribute, "Volume")
 
-	def test_sync_create_new_variant_item_when_synchronising_with_woocommerce(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_variant_item_when_synchronising_with_woocommerce(
+		self, mock_log_error, _name, batch_enabled
+	):
 		"""
 		Test that the Item Synchronisation method creates new Item Variant from a
 		WooCommerce Product Variant
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Create a new product in WooCommerce
 		wc_product_id = self.post_woocommerce_product(
 			product_name="T-SHIRT", type="variation", attributes=["Material Type"]
@@ -169,6 +199,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 			self.wc_server.name, wc_product_id
 		)
 		run_item_sync(woocommerce_product_name=woocommerce_product_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -189,11 +220,16 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 		self.assertIsNotNone(item.attributes[0].attribute_value)
 		self.assertEqual(item.item_name, "T-SHIRT parent - Option 1")
 
-	def test_sync_create_new_wc_product_when_synchronising_with_woocommerce(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_wc_product_when_synchronising_with_woocommerce(
+		self, mock_log_error, _name, batch_enabled
+	):
 		"""
 		Test that the Item Synchronisation method creates a new WooCommerce product when there are new
 		Items.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Create a new item in ERPNext and set a WooCommerce server but not a product ID
 		item = create_item("ITEM101", valuation_rate=10)
 		row = item.append("woocommerce_servers")
@@ -202,6 +238,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_item_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -219,11 +256,16 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 		# Expect correct item name in item
 		self.assertEqual(wc_product["name"], item.item_name)
 
-	def test_sync_create_new_variable_wc_product_when_synchronising_with_woocommerce(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_variable_wc_product_when_synchronising_with_woocommerce(
+		self, mock_log_error, _name, batch_enabled
+	):
 		"""
 		Test that the Item Synchronisation method creates a new Variable WooCommerce product
 		when there is a new Template Item in ERPNext
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Create a new item in ERPNext and set a WooCommerce server but not a product ID
 		item = create_item("ITEM100", valuation_rate=10)
 		row = item.append("woocommerce_servers")
@@ -240,6 +282,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_item_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -258,11 +301,16 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 		self.assertEqual(wc_product["attributes"][1]["name"], "Volume")
 		self.assertEqual(wc_product["attributes"][1]["variation"], True)
 
-	def test_sync_create_new_wc_product_variant_when_synchronising_with_woocommerce(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_wc_product_variant_when_synchronising_with_woocommerce(
+		self, mock_log_error, _name, batch_enabled
+	):
 		"""
 		Test that the Item Synchronisation method creates a new WooCommerce product variant
 		when there is a new Item Variant in ERPNext
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Create a new parent item in ERPNext and set a WooCommerce server but not a product ID
 		parent_item = create_item("ITEM200-Parent", valuation_rate=10)
 		row = parent_item.append("woocommerce_servers")
@@ -288,6 +336,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_item_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -309,13 +358,16 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 		self.assertEqual(wc_product["attributes"][0]["name"], "Material Type")
 		self.assertEqual(wc_product["attributes"][0]["option"], "Option 2")
 
+	@parameterized.expand(BATCH_MODES)
 	def test_sync_create_new_wc_product_with_custom_fields_when_synchronising_with_woocommerce(
-		self, mock_log_error
+		self, mock_log_error, _name, batch_enabled
 	):
 		"""
 		Test that the Item Synchronisation method syncs the mapped custom fields between
 		a WooCommerce product and ERPNext Item.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		dummy_meta_data = [{"id": 52824, "key": "_short_description_1", "value": "Test 1"}]
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
@@ -333,6 +385,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_item_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -348,6 +401,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 		item.description = "Description from ERPNext"
 		item.save()
 		run_item_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		# Expect correct custom mapped field values
 		wc_product = self.get_woocommerce_product(product_id=item.woocommerce_servers[0].woocommerce_id)
@@ -360,6 +414,7 @@ class TestIntegrationWooCommerceItemsSync(TestIntegrationWooCommerce):
 		]
 		self.update_woocommerce_product_metadata(wc_product["id"], new_meta_data)
 		run_item_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		# Get the updated item
 		item.reload()

--- a/woocommerce_fusion/tasks/test_integration_sale_price_sync.py
+++ b/woocommerce_fusion/tasks/test_integration_sale_price_sync.py
@@ -116,7 +116,7 @@ class TestIntegrationSalePriceSync(TestIntegrationWooCommerce):
 
 		product_data = self.get_woocommerce_product(wc_product_id)
 		self.assertEqual(float(product_data["sale_price"]), 60)
-		# WooCommerce returns dates in ISO 8601 — just check the date portion
+		# WooCommerce returns dates in ISO 8601 - just check the date portion
 		self.assertTrue(product_data["date_on_sale_from"].startswith(valid_from))
 		self.assertTrue(product_data["date_on_sale_to"].startswith(valid_upto))
 

--- a/woocommerce_fusion/tasks/test_integration_sale_price_sync.py
+++ b/woocommerce_fusion/tasks/test_integration_sale_price_sync.py
@@ -5,6 +5,7 @@ import frappe
 from erpnext import get_default_company
 from erpnext.stock.doctype.item.test_item import create_item
 from frappe.utils import add_to_date, nowdate
+from parameterized import parameterized
 
 from woocommerce_fusion.tasks.sync_item_prices import run_item_price_sync
 from woocommerce_fusion.tasks.test_integration_helpers import (
@@ -13,6 +14,7 @@ from woocommerce_fusion.tasks.test_integration_helpers import (
 )
 
 SALES_PRICE_LIST = "_Test Sale Price List"
+BATCH_MODES = [("single_call", False), ("batch_api", True)]
 
 
 class TestIntegrationSalePriceSync(TestIntegrationWooCommerce):
@@ -76,25 +78,32 @@ class TestIntegrationSalePriceSync(TestIntegrationWooCommerce):
 		doc.insert()
 		return doc
 
-	def test_sale_price_is_pushed_to_woocommerce(self):
+	@parameterized.expand(BATCH_MODES)
+	def test_sale_price_is_pushed_to_woocommerce(self, _name, batch_enabled):
 		"""
 		Sale price from the Sales Price List should be synced to WooCommerce sale_price.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		wc_product_id = self.post_woocommerce_product(product_name="SALE001", regular_price=100)
 		item = self._create_linked_item("SALE001", wc_product_id)
 		self._create_sale_price("SALE001", rate=75)
 
 		result = run_item_price_sync(item_code=item.name)
+		self._flush_if_batch()
 		self.assertEqual(result, True)
 
 		product_data = self.get_woocommerce_product(wc_product_id)
 		self.assertEqual(float(product_data["sale_price"]), 75)
 
-	def test_sale_price_with_validity_dates_sets_woocommerce_sale_dates(self):
+	@parameterized.expand(BATCH_MODES)
+	def test_sale_price_with_validity_dates_sets_woocommerce_sale_dates(self, _name, batch_enabled):
 		"""
 		When the Item Price has valid_from / valid_upto dates, WooCommerce
 		date_on_sale_from and date_on_sale_to should be populated accordingly.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		wc_product_id = self.post_woocommerce_product(product_name="SALE002", regular_price=100)
 		item = self._create_linked_item("SALE002", wc_product_id)
 
@@ -103,6 +112,7 @@ class TestIntegrationSalePriceSync(TestIntegrationWooCommerce):
 		self._create_sale_price("SALE002", rate=60, valid_from=valid_from, valid_upto=valid_upto)
 
 		run_item_price_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		product_data = self.get_woocommerce_product(wc_product_id)
 		self.assertEqual(float(product_data["sale_price"]), 60)
@@ -110,18 +120,22 @@ class TestIntegrationSalePriceSync(TestIntegrationWooCommerce):
 		self.assertTrue(product_data["date_on_sale_from"].startswith(valid_from))
 		self.assertTrue(product_data["date_on_sale_to"].startswith(valid_upto))
 
-	def test_sale_price_without_validity_dates_has_no_end_date(self):
+	@parameterized.expand(BATCH_MODES)
+	def test_sale_price_without_validity_dates_has_no_end_date(self, _name, batch_enabled):
 		"""
 		When the Item Price has no validity dates, the sale has no end date
 		on WooCommerce. WooCommerce auto-populates date_on_sale_from with the
 		current timestamp when a sale price is set without a start date, but
 		date_on_sale_to must remain null (open-ended sale).
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		wc_product_id = self.post_woocommerce_product(product_name="SALE003", regular_price=100)
 		item = self._create_linked_item("SALE003", wc_product_id)
 		self._create_sale_price("SALE003", rate=80, valid_from=None, valid_upto=None)
 
 		run_item_price_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		product_data = self.get_woocommerce_product(wc_product_id)
 		self.assertEqual(float(product_data["sale_price"]), 80)
@@ -129,32 +143,40 @@ class TestIntegrationSalePriceSync(TestIntegrationWooCommerce):
 		# date_on_sale_to must be null to indicate an open-ended sale.
 		self.assertIsNone(product_data.get("date_on_sale_to"))
 
-	def test_removing_sale_price_clears_woocommerce_sale_price(self):
+	@parameterized.expand(BATCH_MODES)
+	def test_removing_sale_price_clears_woocommerce_sale_price(self, _name, batch_enabled):
 		"""
 		When no Item Price record exists on the Sales Price List for an item,
 		the sale_price on WooCommerce should be cleared (set to "").
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		wc_product_id = self.post_woocommerce_product(product_name="SALE004", regular_price=100)
 		item = self._create_linked_item("SALE004", wc_product_id)
 
 		# First push a sale price so WooCommerce has one
 		sale_price_doc = self._create_sale_price("SALE004", rate=50)
 		run_item_price_sync(item_code=item.name)
+		self._flush_if_batch()
 		self.assertEqual(float(self.get_woocommerce_product(wc_product_id)["sale_price"]), 50)
 
 		# Delete the sale price record and sync again
 		sale_price_doc.delete()
 		run_item_price_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		product_data = self.get_woocommerce_product(wc_product_id)
 		# WooCommerce returns "" or omits the field when no sale price is active
 		self.assertFalse(float(product_data.get("sale_price") or 0) > 0)
 
-	def test_sale_price_sync_skipped_when_feature_disabled(self):
+	@parameterized.expand(BATCH_MODES)
+	def test_sale_price_sync_skipped_when_feature_disabled(self, _name, batch_enabled):
 		"""
 		When enable_sales_price_list_sync is off, WooCommerce sale_price should
 		not be modified even if a sale price record exists in ERPNext.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		wc_product_id = self.post_woocommerce_product(product_name="SALE005", regular_price=100)
 		item = self._create_linked_item("SALE005", wc_product_id)
 		self._create_sale_price("SALE005", rate=45)
@@ -164,6 +186,7 @@ class TestIntegrationSalePriceSync(TestIntegrationWooCommerce):
 		self.wc_server.save()
 
 		run_item_price_sync(item_code=item.name)
+		self._flush_if_batch()
 
 		product_data = self.get_woocommerce_product(wc_product_id)
 		# Sale price should remain unset (WooCommerce default is "")

--- a/woocommerce_fusion/tasks/test_integration_so_sync.py
+++ b/woocommerce_fusion/tasks/test_integration_so_sync.py
@@ -13,6 +13,7 @@ from woocommerce_fusion.tasks.sync_sales_orders import (
 )
 from woocommerce_fusion.tasks.test_integration_helpers import (
 	TestIntegrationWooCommerce,
+	create_gl_account_for_shipping_tax,
 	create_shipping_rule,
 	get_woocommerce_server,
 )
@@ -187,6 +188,10 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		)
 		wc_server.use_actual_tax_type = 0
 		wc_server.sales_taxes_and_charges_template = template_name
+		# On Frappe v16 the shipping tax account must differ from the template's VAT account,
+		# otherwise ERPNext's account-keyed tax map zeroes the calculated VAT (see
+		# WooCommerceServer.validate_tax_account_uniqueness).
+		wc_server.f_n_f_tax_account = create_gl_account_for_shipping_tax()
 		wc_server.flags.ignore_mandatory = True
 		wc_server.shipping_rule_map = []
 		wc_server.save()
@@ -700,6 +705,9 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		)
 		wc_server.use_actual_tax_type = 0
 		wc_server.sales_taxes_and_charges_template = template_name
+		# v16 requires a distinct shipping tax account when a tax template is used (see
+		# WooCommerceServer.validate_tax_account_uniqueness).
+		wc_server.f_n_f_tax_account = create_gl_account_for_shipping_tax()
 		wc_server.flags.ignore_mandatory = True
 		wc_server.save()
 

--- a/woocommerce_fusion/tasks/test_integration_so_sync.py
+++ b/woocommerce_fusion/tasks/test_integration_so_sync.py
@@ -17,6 +17,8 @@ from woocommerce_fusion.tasks.test_integration_helpers import (
 	get_woocommerce_server,
 )
 
+BATCH_MODES = [("single_call", False), ("batch_api", True)]
+
 
 @patch("woocommerce_fusion.tasks.sync_sales_orders.frappe.log_error")
 class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
@@ -64,7 +66,8 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 			).insert()
 		return taxes_and_charges_template.name
 
-	def test_sync_create_new_sales_order(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_sales_order(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method creates a new Sales order when there is a new
 		WooCommerce order.
@@ -73,6 +76,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		- Tax enabled
 		- Sales prices include tax
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Create a new order in WooCommerce
 		wc_order_id, wc_order_name = self.post_woocommerce_order(
 			payment_method_title="Doge", item_price=10, item_qty=1, customer_note="The big brown fox"
@@ -80,6 +84,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -109,7 +114,8 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_create_new_sales_order_in_usd(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_sales_order_in_usd(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method creates a new Sales order in the correct currency
 		when currency is different from base currency
@@ -118,6 +124,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		- Tax enabled
 		- Sales prices include tax
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Create a new order in WooCommerce
 		wc_order_id, wc_order_name = self.post_woocommerce_order(
 			payment_method_title="Doge", item_price=10, item_qty=1, currency="USD"
@@ -125,6 +132,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -139,10 +147,18 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	@parameterized.expand([(True, 50, 13.04, 26.08, 100), (False, 43.48, 13.04, 26.08, 100)])
+	@parameterized.expand(
+		[
+			(False, True, 50, 13.04, 26.08, 100),
+			(True, True, 50, 13.04, 26.08, 100),
+			(False, False, 43.48, 13.04, 26.08, 100),
+			(True, False, 43.48, 13.04, 26.08, 100),
+		]
+	)
 	def test_sync_create_new_sales_order_with_tax_template_and_shipping(
 		self,
 		mock_log_error,
+		batch_enabled,
 		included_in_rate,
 		expected_item_rate,
 		expected_tax_amount,
@@ -157,11 +173,13 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		- Tax enabled, at a rate of 15%
 		- Sales prices include tax
 
-		Parameterisation: (included_in_rate, expected item.rate, expected tax_amount, expected total_tax_amount)
+		Parameterisation: (batch_enabled, included_in_rate, expected item.rate, expected tax_amount, expected total_tax_amount)
 		1. Tax Template that includes tax so Item Rate should include Tax (=50), and tax should be 50 x 2 x 15/115 = 13.04
 		2. Tax Template that excludes tax so Item Rate should exclude Tax (=43.48), and tax should be 50 x 2 x 15/115 = 13.04
 
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		template_name = self._create_sales_taxes_and_charges_template(
@@ -180,6 +198,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -211,16 +230,19 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_create_new_sales_order_and_pe(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_sales_order_and_pe(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method creates a new Sales orders and a Payment Entry
 		when there is a new fully paid WooCommerce orders.
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Create a new order in WooCommerce
 		wc_order_id, wc_order_name = self.post_woocommerce_order(set_paid=True)
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 		mock_log_error.assert_not_called()
 
 		# Expect newly created Sales Order and linked Payment Entry in ERPNext
@@ -232,11 +254,13 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_create_new_draft_sales_order(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_draft_sales_order(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method creates a new Draft Sales order without errors
 		when the submit_sales_orders setting is set to 0
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		wc_server.submit_sales_orders = 0
@@ -249,6 +273,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 		mock_log_error.assert_not_called()
 
 		# Expect newly created Sales Order in ERPNext
@@ -264,11 +289,13 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_link_payment_entry_after_so_submitted(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_link_payment_entry_after_so_submitted(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method creates a linked Payment Entry if there are no linked
 		PE's on a now-submitted Sales Order
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		wc_server.submit_sales_orders = 0
@@ -280,6 +307,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 		mock_log_error.assert_not_called()
 
 		# Expect no linked Payment Entry
@@ -292,6 +320,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation again
 		run_sales_order_sync(sales_order_name=sales_order.name)
+		self._flush_if_batch()
 		mock_log_error.assert_not_called()
 
 		# Expect linked Payment Entry this time
@@ -302,11 +331,13 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_create_new_sales_order_with_mapped_field(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_create_new_sales_order_with_mapped_field(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method creates a new Sales order when there is a new
 		WooCommerce order, and that mapped fields are taken into account
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		# Map Erpnext Sales Order Item description to WC Order Line Meta Data with key 'custom_field'
@@ -327,6 +358,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -342,11 +374,13 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_updates_woocommerce_order(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_updates_woocommerce_order(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method updates a WooCommerce Order
 		with changed fields from Sales Order
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		wc_server.submit_sales_orders = 0
@@ -373,6 +407,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation for the ERPNext Sales Order to be created
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -399,6 +434,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation again, to sync the Sales Order changes
 		run_sales_order_sync(sales_order_name=sales_order.name)
+		self._flush_if_batch()
 		mock_log_error.assert_not_called()
 
 		# Expect WooCommerce Order to have updated items
@@ -412,11 +448,13 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_updates_woocommerce_order_with_mapped_field(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_updates_woocommerce_order_with_mapped_field(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method updates a WooCommerce Order
 		with changed fields from Sales Order, and that mapped fields are taken into account
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		wc_server.submit_sales_orders = 0
@@ -453,6 +491,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation for the ERPNext Sales Order to be created
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -469,6 +508,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation again, to sync the Sales Order changes
 		run_sales_order_sync(sales_order_name=sales_order.name)
+		self._flush_if_batch()
 		mock_log_error.assert_not_called()
 
 		# Expect WooCommerce Order to have updated items
@@ -479,11 +519,13 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_uses_dummy_item_for_deleted_item(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_uses_dummy_item_for_deleted_item(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method uses a placeholder item when
 		synchronising with a WooCommerce Order that has a deleted item
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		wc_server.submit_sales_orders = 0
@@ -501,6 +543,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 		mock_log_error.assert_not_called()
 
 		# Expect newly created Sales Order in ERPNext
@@ -520,11 +563,13 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_use_same_customer_for_multiple_orders(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_use_same_customer_for_multiple_orders(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method does not create a duplicate Customer when the same
 		customer places another order
 		"""
+		self._set_batch_mode(batch_enabled)
 		same_customer_email = "same@customer.com"
 
 		# Create a new order in WooCommerce
@@ -534,6 +579,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name_first)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -567,6 +613,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name_second)
+		self._flush_if_batch()
 
 		# Expect that the order has been allocated to the initial customer
 		_sales_order_name, sales_order_customer = frappe.get_value(
@@ -583,11 +630,13 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		self.delete_woocommerce_order(wc_order_id=wc_order_id_first)
 		self.delete_woocommerce_order(wc_order_id=wc_order_id_second)
 
-	def test_sync_links_shipping_rule(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_links_shipping_rule(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method links a Shipping Rule on the created
 		Sales order when Shipping Rule Sync is enabled and a mapping exists.
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup: Create a Shipping Rule
 		sr = create_shipping_rule(shipping_rule_type="Selling", shipping_rule_name="Woo Shipping")
 
@@ -609,6 +658,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -624,12 +674,14 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_with_shipping_rule_and_tax_template(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_with_shipping_rule_and_tax_template(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method links a Shipping Rule on the created
 		Sales order when Shipping Rule Sync is enabled and a mapping exists, and handles
 		a Sales Tax Templates at the same without duplicating shipping charges
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup: Create a Shipping Rule
 		sr = create_shipping_rule(shipping_rule_type="Selling", shipping_rule_name="Woo Shipping")
 
@@ -658,6 +710,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -682,12 +735,15 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
+	@parameterized.expand(BATCH_MODES)
 	@patch("woocommerce_fusion.tasks.sync_sales_orders.frappe.enqueue")
-	def test_sync_updates_woocommerce_order_status(self, mock_enqueue, mock_log_error):
+	def test_sync_updates_woocommerce_order_status(self, _name, batch_enabled, mock_enqueue, mock_log_error):
 		"""
 		Test that the Sales Order Synchronisation method updates a WooCommerce Order's status
 		with the correct mapped value if auto status sync is enabled
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		wc_server.submit_sales_orders = 1
@@ -711,6 +767,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation for the ERPNext Sales Order to be created
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -725,6 +782,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation again, to sync the Sales Order changes
 		run_sales_order_sync(sales_order_name=sales_order.name)
+		self._flush_if_batch()
 		mock_log_error.assert_not_called()
 
 		# Expect WooCommerce Order to have updated status
@@ -734,11 +792,13 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_so_items_to_wc_preserves_metadata(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_so_items_to_wc_preserves_metadata(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that when 'sync_so_items_to_wc' is enabled, changes to ERPNext Sales Order
 		are synced to WooCommerce Order while preserving metadata on the WooCommerce Order Line Items.
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		wc_server.sync_so_items_to_wc = 1
@@ -756,6 +816,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation for the ERPNext Sales Order to be created
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -772,6 +833,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation again, to sync the Sales Order changes
 		run_sales_order_sync(sales_order_name=sales_order.name)
+		self._flush_if_batch()
 		mock_log_error.assert_not_called()
 
 		# Expect WooCommerce Order to have updated items and preserved metadata
@@ -785,7 +847,8 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_sync_so_with_coupon(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_sync_so_with_coupon(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that the Sales Order Synchronisation method creates a new Sales order when there is a new
 		WooCommerce order, and that coupons are taken into account
@@ -794,6 +857,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		- Tax enabled
 		- Sales prices include tax
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Create a new coupon in WooCommerce
 		coupon_code = f"10off_{frappe.generate_hash()}"
 		_coupon_id = self.post_woocommerce_coupon(coupon_code=coupon_code, percent_discount=10)
@@ -808,6 +872,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -834,10 +899,12 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_order_fee_lines_are_synced_when_enabled(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_order_fee_lines_are_synced_when_enabled(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that Order Fee Lines are synchronised when enabled
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		wc_server.enable_order_fees_sync = 1
@@ -869,6 +936,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation for the ERPNext Sales Order to be created
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()
@@ -894,10 +962,12 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		# Delete order in WooCommerce
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
-	def test_order_negative_fee_lines_are_synced_when_enabled(self, mock_log_error):
+	@parameterized.expand(BATCH_MODES)
+	def test_order_negative_fee_lines_are_synced_when_enabled(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that Negative Order Fee Lines are synchronised when enabled
 		"""
+		self._set_batch_mode(batch_enabled)
 		# Setup
 		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
 		wc_server.enable_order_fees_sync = 1
@@ -929,6 +999,7 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation for the ERPNext Sales Order to be created
 		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
 
 		# Expect no errors logged
 		mock_log_error.assert_not_called()

--- a/woocommerce_fusion/tasks/test_integration_so_sync.py
+++ b/woocommerce_fusion/tasks/test_integration_so_sync.py
@@ -801,6 +801,66 @@ class TestIntegrationWooCommerceSync(TestIntegrationWooCommerce):
 		self.delete_woocommerce_order(wc_order_id=wc_order_id)
 
 	@parameterized.expand(BATCH_MODES)
+	@patch("woocommerce_fusion.tasks.sync_sales_orders.frappe.enqueue")
+	def test_sync_does_not_update_woocommerce_order_status_when_disabled(
+		self, _name, batch_enabled, mock_enqueue, mock_log_error
+	):
+		"""
+		When Sales Order Status Sync is DISABLED, syncing
+		an ERPNext Sales Order that is newer than its WooCommerce Order (e.g. after submitting it)
+		must not change the linked WooCommerce Order's status.
+		"""
+		self._set_batch_mode(batch_enabled)
+
+		# Setup: status sync disabled, but a status map is present, so the only thing preventing
+		# an outbound status push is the disabled flag
+		wc_server = frappe.get_doc("WooCommerce Server", self.wc_server.name)
+		wc_server.submit_sales_orders = 0
+		wc_server.enable_payments_sync = 0
+		wc_server.enable_so_status_sync = 0
+		wc_server.sales_order_status_map = []
+		wc_server.append(
+			"sales_order_status_map",
+			{
+				"erpnext_sales_order_status": "On Hold",
+				"woocommerce_sales_order_status": "On hold",
+			},
+		)
+		wc_server.flags.ignore_mandatory = True
+		wc_server.save()
+
+		# Create a new order in WooCommerce and sync it to ERPNext
+		wc_order_id, wc_order_name = self.post_woocommerce_order(
+			payment_method_title="Doge", item_price=10, item_qty=3
+		)
+		run_sales_order_sync(woocommerce_order_name=wc_order_name)
+		self._flush_if_batch()
+		mock_log_error.assert_not_called()
+
+		sales_order_name = frappe.get_value("Sales Order", {"woocommerce_id": wc_order_id}, "name")
+		self.assertIsNotNone(sales_order_name)
+
+		# In WooCommerce change the order's status
+		self.update_woocommerce_order_status(wc_order_id, "completed")
+
+		# Submit the ERPNext Sales Order so it becomes newer than the WooCommerce Order, routing
+		# the next sync through the outbound (ERPNext -> WooCommerce) path
+		sales_order = frappe.get_doc("Sales Order", sales_order_name)
+		sales_order.submit()
+
+		# Run synchronisation again
+		run_sales_order_sync(sales_order_name=sales_order.name)
+		self._flush_if_batch()
+		mock_log_error.assert_not_called()
+
+		# Expect the WooCommerce Order status to be unchanged (not reverted by ERPNext)
+		wc_order = self.get_woocommerce_order(order_id=wc_order_id)
+		self.assertEqual(wc_order["status"], "completed")
+
+		# Delete order in WooCommerce
+		self.delete_woocommerce_order(wc_order_id=wc_order_id)
+
+	@parameterized.expand(BATCH_MODES)
 	def test_sync_so_items_to_wc_preserves_metadata(self, mock_log_error, _name, batch_enabled):
 		"""
 		Test that when 'sync_so_items_to_wc' is enabled, changes to ERPNext Sales Order

--- a/woocommerce_fusion/tasks/test_integration_stock_update.py
+++ b/woocommerce_fusion/tasks/test_integration_stock_update.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 import frappe
 from erpnext import get_default_company
 from erpnext.stock.doctype.item.test_item import create_item
+from parameterized import parameterized
 
 from woocommerce_fusion.tasks.stock_update import update_stock_levels_on_woocommerce_site
 from woocommerce_fusion.tasks.test_integration_helpers import (
@@ -11,16 +12,21 @@ from woocommerce_fusion.tasks.test_integration_helpers import (
 	get_woocommerce_server,
 )
 
+BATCH_MODES = [("single_call", False), ("batch_api", True)]
+
 
 class TestIntegrationWooCommerceStockSync(TestIntegrationWooCommerce):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()  # important to call super() methods when extending TestCase.
 
-	def test_stock_sync_when_synchronising_with_woocommerce(self):
+	@parameterized.expand(BATCH_MODES)
+	def test_stock_sync_when_synchronising_with_woocommerce(self, _name, batch_enabled):
 		"""
 		Test that the Stock Synchronisation method posts the correct stock level to a WooCommerce website.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Create a new product in WooCommerce, set opening stock to 1
 		wc_product_id = self.post_woocommerce_product(product_name="ITEM009", opening_stock=1)
 
@@ -40,6 +46,7 @@ class TestIntegrationWooCommerceStockSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		stock_update_result = update_stock_levels_on_woocommerce_site(item_code=item.name)
+		self._flush_if_batch()
 
 		# Expect successful update
 		self.assertEqual(stock_update_result, True)
@@ -48,11 +55,14 @@ class TestIntegrationWooCommerceStockSync(TestIntegrationWooCommerce):
 		wc_stock_level = self.get_woocommerce_product_stock_level(product_id=wc_product_id)
 		self.assertEqual(wc_stock_level, 5)
 
-	def test_stock_sync_with_decimal_when_synchronising_with_woocommerce(self):
+	@parameterized.expand(BATCH_MODES)
+	def test_stock_sync_with_decimal_when_synchronising_with_woocommerce(self, _name, batch_enabled):
 		"""
 		Test that the Stock Synchronisation method posts the correct stock level to a WooCommerce website
 		while handling decimals.
 		"""
+		self._set_batch_mode(batch_enabled)
+
 		# Create a new product in WooCommerce, set opening stock to 1
 		wc_product_id = self.post_woocommerce_product(product_name="ITEM002", opening_stock=1)
 
@@ -72,6 +82,7 @@ class TestIntegrationWooCommerceStockSync(TestIntegrationWooCommerce):
 
 		# Run synchronisation
 		stock_update_result = update_stock_levels_on_woocommerce_site(item_code=item.name)
+		self._flush_if_batch()
 
 		# Expect successful update
 		self.assertEqual(stock_update_result, True)

--- a/woocommerce_fusion/tasks/test_sync_items.py
+++ b/woocommerce_fusion/tasks/test_sync_items.py
@@ -235,8 +235,10 @@ class TestWooCommerceSync(FrappeTestCase):
 	@patch("frappe.get_cached_doc")
 	@patch("frappe.get_doc")
 	@patch("woocommerce_fusion.tasks.sync_items.get_item_price_rate")
+	@patch("woocommerce_fusion.tasks.sync_items.get_item_sale_price_data")
 	def test_create_woocommerce_product(
 		self,
+		mock_get_item_sale_price_data,
 		mock_get_item_price_rate,
 		mock_get_doc,
 		mock_get_cached_doc,
@@ -249,6 +251,7 @@ class TestWooCommerceSync(FrappeTestCase):
 
 		mock_get_doc.return_value = wc_product_mock
 		mock_get_item_price_rate.return_value = "100.00"
+		mock_get_item_sale_price_data.return_value = None
 
 		# Create a mock ERPNextItemToSync
 		item_woocommerce_server_mock = MagicMock()
@@ -284,8 +287,10 @@ class TestWooCommerceSync(FrappeTestCase):
 	@patch("frappe.get_cached_doc")
 	@patch("frappe.get_doc")
 	@patch("woocommerce_fusion.tasks.sync_items.get_item_price_rate")
+	@patch("woocommerce_fusion.tasks.sync_items.get_item_sale_price_data")
 	def test_create_woocommerce_product_from_variant(
 		self,
+		mock_get_item_sale_price_data,
 		mock_get_item_price_rate,
 		mock_get_doc,
 		mock_get_cached_doc,
@@ -301,6 +306,7 @@ class TestWooCommerceSync(FrappeTestCase):
 		mock_get_doc.side_effect = [wc_product_mock, parent_item_mock]
 
 		mock_get_item_price_rate.return_value = "100.00"
+		mock_get_item_sale_price_data.return_value = None
 
 		mock_run_item_sync.return_value = (None, parent_item_mock)
 
@@ -335,8 +341,10 @@ class TestWooCommerceSync(FrappeTestCase):
 	@patch("frappe.get_cached_doc")
 	@patch("frappe.get_doc")
 	@patch("woocommerce_fusion.tasks.sync_items.get_item_price_rate")
+	@patch("woocommerce_fusion.tasks.sync_items.get_item_sale_price_data")
 	def test_create_woocommerce_product_from_template_item(
 		self,
+		mock_get_item_sale_price_data,
 		mock_get_item_price_rate,
 		mock_get_doc,
 		mock_get_cached_doc,
@@ -349,6 +357,7 @@ class TestWooCommerceSync(FrappeTestCase):
 		mock_get_doc.return_value = wc_product_mock
 
 		mock_get_item_price_rate.return_value = "100.00"
+		mock_get_item_sale_price_data.return_value = None
 
 		# Create a mock ERPNextItemToSync
 		item_woocommerce_server_mock = MagicMock()

--- a/woocommerce_fusion/tasks/utils.py
+++ b/woocommerce_fusion/tasks/utils.py
@@ -6,20 +6,6 @@ from frappe.utils.caching import redis_cache
 from woocommerce import API
 
 
-def commit_unless_in_test() -> None:
-	"""
-	Commit the current transaction, unless running under the test runner.
-
-	The batch flush relies on intermediate commits (to release the row lock and to persist
-	batch-log progress). Tests, however, rely on transaction rollback for isolation; committing
-	inside a test would leak data across test methods and across the two batch-mode variants of
-	each parameterised test.
-	"""
-	if not frappe.flags.in_test:
-		# nosemgrep
-		frappe.db.commit()
-
-
 class APIWithRequestLogging(API):
 	"""WooCommerce API with Request Logging."""
 

--- a/woocommerce_fusion/tasks/utils.py
+++ b/woocommerce_fusion/tasks/utils.py
@@ -6,6 +6,19 @@ from frappe.utils.caching import redis_cache
 from woocommerce import API
 
 
+def commit_unless_in_test() -> None:
+	"""
+	Commit the current transaction, unless running under the test runner.
+
+	The batch flush relies on intermediate commits (to release the row lock and to persist
+	batch-log progress). Tests, however, rely on transaction rollback for isolation; committing
+	inside a test would leak data across test methods and across the two batch-mode variants of
+	each parameterised test.
+	"""
+	if not frappe.flags.in_test:
+		frappe.db.commit()
+
+
 class APIWithRequestLogging(API):
 	"""WooCommerce API with Request Logging."""
 

--- a/woocommerce_fusion/tasks/utils.py
+++ b/woocommerce_fusion/tasks/utils.py
@@ -16,6 +16,7 @@ def commit_unless_in_test() -> None:
 	each parameterised test.
 	"""
 	if not frappe.flags.in_test:
+		# nosemgrep
 		frappe.db.commit()
 
 

--- a/woocommerce_fusion/utils.py
+++ b/woocommerce_fusion/utils.py
@@ -8,7 +8,7 @@ def before_tests():
 	# complete setup if missing
 	from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
 
-	if not frappe.db.a_row_exists("Company"):
+	if not frappe.db.exists("Company", "Some Company (Pty) Ltd"):
 		current_year = now_datetime().year
 		setup_complete(
 			{
@@ -28,46 +28,22 @@ def before_tests():
 				"chart_of_accounts": "Standard",
 			}
 		)
-	elif not frappe.db.exists("Company", "Some Company (Pty) Ltd"):
-		# For running tests in v16
-		frappe.get_doc(
-			{
-				"doctype": "Company",
-				"company_name": "Some Company (Pty) Ltd",
-				"abbr": "SC",
-				"default_currency": "INR",
-				"country": "South Africa",
-				"chart_of_accounts": "Standard",
-			}
-		).insert()
-
-	if not frappe.db.exists("User", "test@erpnext.com"):
-		# For running tests in v16
-		frappe.get_doc(
-			{
-				"doctype": "User",
-				"email": "test@erpnext.com",
-				"first_name": "Test",
-				"send_welcome_email": 0,
-			}
-		).insert(ignore_permissions=True)
-
-	# For running tests in v16
-	global_defaults = frappe.get_single("Global Defaults")
-	if global_defaults.default_company != "Some Company (Pty) Ltd":
-		global_defaults.default_company = "Some Company (Pty) Ltd"
-		global_defaults.save()
 
 	_enable_all_roles_for_admin()
 
 	set_defaults_for_tests()
 	create_curr_exchange_record()
 
-	# v16 scenario
+	# set_defaults_for_tests() points the default customer_group at the ROOT (a group) node, which
+	# v16 rejects as a Customer's group; point it at a real (non-group) customer group instead.
 	non_group_customer_group = frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
 	if non_group_customer_group:
 		frappe.db.set_default("customer_group", non_group_customer_group)
 		frappe.db.set_single_value("Selling Settings", "customer_group", non_group_customer_group)
+
+	# Set default for v16
+	if frappe.db.exists("Warehouse", "Stores - SC"):
+		frappe.db.set_single_value("Stock Settings", "default_warehouse", "Stores - SC")
 
 	# following same practice as in erpnext app to commit manually inside before_tests
 	# nosemgrep

--- a/woocommerce_fusion/utils.py
+++ b/woocommerce_fusion/utils.py
@@ -28,11 +28,46 @@ def before_tests():
 				"chart_of_accounts": "Standard",
 			}
 		)
+	elif not frappe.db.exists("Company", "Some Company (Pty) Ltd"):
+		# For running tests in v16
+		frappe.get_doc(
+			{
+				"doctype": "Company",
+				"company_name": "Some Company (Pty) Ltd",
+				"abbr": "SC",
+				"default_currency": "INR",
+				"country": "South Africa",
+				"chart_of_accounts": "Standard",
+			}
+		).insert()
+
+	if not frappe.db.exists("User", "test@erpnext.com"):
+		# For running tests in v16
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": "test@erpnext.com",
+				"first_name": "Test",
+				"send_welcome_email": 0,
+			}
+		).insert(ignore_permissions=True)
+
+	# For running tests in v16
+	global_defaults = frappe.get_single("Global Defaults")
+	if global_defaults.default_company != "Some Company (Pty) Ltd":
+		global_defaults.default_company = "Some Company (Pty) Ltd"
+		global_defaults.save()
 
 	_enable_all_roles_for_admin()
 
 	set_defaults_for_tests()
 	create_curr_exchange_record()
+
+	# v16 scenario
+	non_group_customer_group = frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
+	if non_group_customer_group:
+		frappe.db.set_default("customer_group", non_group_customer_group)
+		frappe.db.set_single_value("Selling Settings", "customer_group", non_group_customer_group)
 
 	# following same practice as in erpnext app to commit manually inside before_tests
 	# nosemgrep

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_batch_log/woocommerce_batch_log.json
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_batch_log/woocommerce_batch_log.json
@@ -1,0 +1,129 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-06-16 00:00:00.000000",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "woocommerce_server",
+  "resource_type",
+  "flush_reason",
+  "status",
+  "column_break_main",
+  "total_items",
+  "successful_items",
+  "failed_items",
+  "flushed_at",
+  "payload_section",
+  "request_payload",
+  "response_payload"
+ ],
+ "fields": [
+  {
+   "fieldname": "woocommerce_server",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "WooCommerce Server",
+   "options": "WooCommerce Server",
+   "reqd": 1
+  },
+  {
+   "fieldname": "resource_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Resource Type"
+  },
+  {
+   "fieldname": "flush_reason",
+   "fieldtype": "Select",
+   "label": "Flush Reason",
+   "options": "buffer_full\ntimer_elapsed\nmanual"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Processing\nCompleted\nPartial\nFailed"
+  },
+  {
+   "fieldname": "column_break_main",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_items",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Total Items"
+  },
+  {
+   "fieldname": "successful_items",
+   "fieldtype": "Int",
+   "label": "Successful"
+  },
+  {
+   "fieldname": "failed_items",
+   "fieldtype": "Int",
+   "label": "Failed"
+  },
+  {
+   "fieldname": "flushed_at",
+   "fieldtype": "Datetime",
+   "label": "Flushed At"
+  },
+  {
+   "fieldname": "payload_section",
+   "fieldtype": "Section Break",
+   "label": "Payloads"
+  },
+  {
+   "fieldname": "request_payload",
+   "fieldtype": "Code",
+   "label": "Request Payload",
+   "options": "JSON"
+  },
+  {
+   "fieldname": "response_payload",
+   "fieldtype": "Code",
+   "label": "Response Payload",
+   "options": "JSON"
+  }
+ ],
+ "grid_page_length": 50,
+ "in_create": 1,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-06-16 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "WooCommerce",
+ "name": "WooCommerce Batch Log",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Stock Manager"
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_batch_log/woocommerce_batch_log.py
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_batch_log/woocommerce_batch_log.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, Dirk van der Laarse and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+
+class WooCommerceBatchLog(Document):
+	@staticmethod
+	def clear_old_logs(days=30):
+		from frappe.query_builder import Interval
+		from frappe.query_builder.functions import Now
+
+		table = frappe.qb.DocType("WooCommerce Batch Log")
+		frappe.db.delete(table, filters=(table.modified < (Now() - Interval(days=days))))

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_order/test_woocommerce_order.py
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_order/test_woocommerce_order.py
@@ -18,6 +18,8 @@ from woocommerce_fusion.woocommerce.doctype.woocommerce_order.woocommerce_order 
 from woocommerce_fusion.woocommerce.woocommerce_api import (
 	generate_woocommerce_record_name_from_domain_and_id,
 	get_domain_and_id_from_woocommerce_record_name,
+	get_wc_parameters_from_filters,
+	get_woocommerce_servers_from_filters,
 )
 
 
@@ -532,6 +534,97 @@ class TestWooCommerceOrder(FrappeTestCase):
 		domain, order_id = get_domain_and_id_from_woocommerce_record_name(name, delimiter)
 		self.assertEqual(domain, "site2.example.com")
 		self.assertEqual(order_id, 3)
+
+
+# Mirrors WooCommerceProduct.field_setter_map
+PRODUCT_FIELD_SETTER_MAP = {"woocommerce_name": "name", "woocommerce_id": "id"}
+
+
+class TestGetWcParametersFromFilters(FrappeTestCase):
+	"""
+	Unit tests for get_wc_parameters_from_filters
+	"""
+
+	def test_order_id_equals_maps_to_include(self):
+		params = get_wc_parameters_from_filters([["WooCommerce Order", "id", "=", "11"]])
+		self.assertEqual(params, {"include": ["11"]})
+
+	def test_product_woocommerce_id_equals_maps_to_include(self):
+		params = get_wc_parameters_from_filters(
+			[["WooCommerce Product", "woocommerce_id", "=", "11"]], self.PRODUCT_FIELD_SETTER_MAP
+		)
+		self.assertEqual(params, {"include": ["11"]})
+
+	def test_product_woocommerce_id_in_maps_to_include(self):
+		params = get_wc_parameters_from_filters(
+			[["WooCommerce Product", "woocommerce_id", "in", ["11", "12"]]], self.PRODUCT_FIELD_SETTER_MAP
+		)
+		self.assertEqual(params, {"include": "11,12"})
+
+	def test_product_woocommerce_name_like_maps_to_search(self):
+		params = get_wc_parameters_from_filters(
+			[["WooCommerce Product", "woocommerce_name", "like", "%hoodie%"]], self.PRODUCT_FIELD_SETTER_MAP
+		)
+		self.assertEqual(params, {"search": "hoodie"})
+
+	def test_order_name_equals_extracts_id_and_maps_to_include(self):
+		params = get_wc_parameters_from_filters([["WooCommerce Order", "name", "=", "woo-test.localhost~75"]])
+		self.assertEqual(params, {"include": [75]})
+
+	def test_order_name_equals_without_delimiter_uses_raw_value(self):
+		params = get_wc_parameters_from_filters([["WooCommerce Order", "name", "=", "75"]])
+		self.assertEqual(params, {"include": ["75"]})
+
+	def test_order_name_in_extracts_ids_and_maps_to_include(self):
+		params = get_wc_parameters_from_filters(
+			[["WooCommerce Order", "name", "in", ["woo-test.localhost~75", "woo-test.localhost~76"]]]
+		)
+		self.assertEqual(params, {"include": "75,76"})
+
+	def test_order_name_like_still_maps_to_search(self):
+		params = get_wc_parameters_from_filters([["WooCommerce Order", "name", "like", "%11%"]])
+		self.assertEqual(params, {"search": "11"})
+
+	def test_woocommerce_server_filter_is_not_a_wc_param(self):
+		params = get_wc_parameters_from_filters(
+			[["WooCommerce Order", "woocommerce_server", "=", "woo-test.localhost"]]
+		)
+		self.assertEqual(params, {})
+
+	def test_unsupported_field_reports_original_field_name(self):
+		with self.assertRaises(frappe.exceptions.ValidationError) as context:
+			get_wc_parameters_from_filters(
+				[["WooCommerce Product", "sku", "=", "ABC"]], self.PRODUCT_FIELD_SETTER_MAP
+			)
+		self.assertIn("sku", str(context.exception))
+
+
+class TestGetWoocommerceServersFromFilters(FrappeTestCase):
+	"""Unit tests for get_woocommerce_servers_from_filters (GitHub issue #220)."""
+
+	def test_name_equals_scopes_to_servers_domain(self):
+		servers = get_woocommerce_servers_from_filters(
+			[["WooCommerce Order", "name", "=", "woo-test.localhost~75"]]
+		)
+		self.assertEqual(servers, {"woo-test.localhost"})
+
+	def test_name_in_scopes_to_all_referenced_servers(self):
+		servers = get_woocommerce_servers_from_filters(
+			[["WooCommerce Order", "name", "in", ["woo-test.localhost~75", "shop2.example.com~3"]]]
+		)
+		self.assertEqual(servers, {"woo-test.localhost", "shop2.example.com"})
+
+	def test_woocommerce_server_equals_scopes_to_that_server(self):
+		servers = get_woocommerce_servers_from_filters(
+			[["WooCommerce Order", "woocommerce_server", "=", "woo-test.localhost"]]
+		)
+		self.assertEqual(servers, {"woo-test.localhost"})
+
+	def test_no_server_constraint_returns_none(self):
+		self.assertIsNone(
+			get_woocommerce_servers_from_filters([["WooCommerce Order", "status", "=", "processing"]])
+		)
+		self.assertIsNone(get_woocommerce_servers_from_filters([["WooCommerce Order", "id", "=", "75"]]))
 
 
 def wc_response_for_list_of_orders(nr_of_orders=5, site="example.com"):

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_order/test_woocommerce_order.py
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_order/test_woocommerce_order.py
@@ -551,19 +551,19 @@ class TestGetWcParametersFromFilters(FrappeTestCase):
 
 	def test_product_woocommerce_id_equals_maps_to_include(self):
 		params = get_wc_parameters_from_filters(
-			[["WooCommerce Product", "woocommerce_id", "=", "11"]], self.PRODUCT_FIELD_SETTER_MAP
+			[["WooCommerce Product", "woocommerce_id", "=", "11"]], PRODUCT_FIELD_SETTER_MAP
 		)
 		self.assertEqual(params, {"include": ["11"]})
 
 	def test_product_woocommerce_id_in_maps_to_include(self):
 		params = get_wc_parameters_from_filters(
-			[["WooCommerce Product", "woocommerce_id", "in", ["11", "12"]]], self.PRODUCT_FIELD_SETTER_MAP
+			[["WooCommerce Product", "woocommerce_id", "in", ["11", "12"]]], PRODUCT_FIELD_SETTER_MAP
 		)
 		self.assertEqual(params, {"include": "11,12"})
 
 	def test_product_woocommerce_name_like_maps_to_search(self):
 		params = get_wc_parameters_from_filters(
-			[["WooCommerce Product", "woocommerce_name", "like", "%hoodie%"]], self.PRODUCT_FIELD_SETTER_MAP
+			[["WooCommerce Product", "woocommerce_name", "like", "%hoodie%"]], PRODUCT_FIELD_SETTER_MAP
 		)
 		self.assertEqual(params, {"search": "hoodie"})
 
@@ -594,7 +594,7 @@ class TestGetWcParametersFromFilters(FrappeTestCase):
 	def test_unsupported_field_reports_original_field_name(self):
 		with self.assertRaises(frappe.exceptions.ValidationError) as context:
 			get_wc_parameters_from_filters(
-				[["WooCommerce Product", "sku", "=", "ABC"]], self.PRODUCT_FIELD_SETTER_MAP
+				[["WooCommerce Product", "sku", "=", "ABC"]], PRODUCT_FIELD_SETTER_MAP
 			)
 		self.assertIn("sku", str(context.exception))
 

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.js
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.js
@@ -3,6 +3,30 @@
 
 frappe.ui.form.on("WooCommerce Server", {
   refresh: function (frm) {
+    if (frm.doc.enable_batch_api) {
+      frm.add_custom_button(
+        __("Sync Status Dashboard"),
+        () => frappe.set_route("woocommerce-sync-status"),
+        __("Batch API"),
+      );
+      frm.add_custom_button(
+        __("Flush Queue Now"),
+        () => {
+          frappe.call({
+            method: "woocommerce_fusion.tasks.batch.queue_manager.manual_flush",
+            args: { server_name: frm.doc.name },
+            callback: function (r) {
+              frappe.show_alert({
+                message: JSON.stringify(r.message),
+                indicator: "green",
+              });
+            },
+          });
+        },
+        __("Batch API"),
+      );
+    }
+
     // Only list enabled warehouses
     frm.fields_dict.warehouses.get_query = function (doc) {
       return {

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.json
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.json
@@ -401,7 +401,7 @@
    "documentation_url": "https://woocommerce-fusion-docs.starktail.com/woocommerce_fusion_item-stock-levels",
    "fieldname": "enable_stock_level_synchronisation",
    "fieldtype": "Check",
-   "label": "Enable Stock Level Synchronisation"
+   "label": "Sync stock levels from ERPNext to WooCommerce (1-way)"
   },
   {
    "default": "WooCommerce ID",
@@ -670,7 +670,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-18 13:41:35.615517",
+ "modified": "2026-06-18 15:20:52.859238",
  "modified_by": "Administrator",
  "module": "WooCommerce",
  "name": "WooCommerce Server",

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.json
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.json
@@ -14,6 +14,10 @@
   "column_break_ikke",
   "api_consumer_key",
   "api_consumer_secret",
+  "batch_api_section",
+  "enable_batch_api",
+  "batch_flush_interval_minutes",
+  "batch_size_limit",
   "section_details_defaults",
   "creation_user",
   "column_break_14",
@@ -454,6 +458,34 @@
    "options": "<div class=\"alert alert-warning\">\nMapping item fields is recommended for advanced users only. Make sure to monitor Error Logs after adding field mappings.\n</div>"
   },
   {
+   "fieldname": "batch_api_section",
+   "fieldtype": "Section Break",
+   "label": "Batch API"
+  },
+  {
+   "default": "0",
+   "description": "Group sync operations into batch API calls instead of one-at-a-time. Reduces WooCommerce server load significantly.",
+   "fieldname": "enable_batch_api",
+   "fieldtype": "Check",
+   "label": "Enable Batch API"
+  },
+  {
+   "default": "1",
+   "depends_on": "eval:doc.enable_batch_api",
+   "description": "Maximum time (in minutes) a sync operation waits in the queue before being flushed. Min: 1, Max: 60. For near-real-time feel, set to 1.",
+   "fieldname": "batch_flush_interval_minutes",
+   "fieldtype": "Int",
+   "label": "Flush Interval (minutes)"
+  },
+  {
+   "default": "100",
+   "depends_on": "eval:doc.enable_batch_api",
+   "description": "Number of operations to accumulate before flushing early. WooCommerce maximum is 100.",
+   "fieldname": "batch_size_limit",
+   "fieldtype": "Int",
+   "label": "Batch Size Limit"
+  },
+  {
    "fieldname": "column_break_tefw",
    "fieldtype": "Column Break"
   },
@@ -638,7 +670,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-22 09:36:31.805564",
+ "modified": "2026-06-18 13:41:35.615517",
  "modified_by": "Administrator",
  "module": "WooCommerce",
  "name": "WooCommerce Server",

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.py
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.py
@@ -42,6 +42,43 @@ class WooCommerceServer(Document):
 		self.validate_item_map()
 		self.validate_reserved_stock_setting()
 		self.validate_batch_settings()
+		self.validate_tax_account_uniqueness()
+
+	def validate_tax_account_uniqueness(self):
+		"""
+		On Frappe v16+, ERPNext builds the per-item tax map keyed by account head with
+		last-write-wins semantics (erpnext.stock.get_item_details.get_item_tax_map). When a
+		"Sales Taxes and Charges Template" with a calculated ("On Net Total") VAT row is used,
+		an additional "Actual" tax line (e.g. shipping or fee tax) re-using the same account head
+		overwrites the VAT rate with the Actual line's (empty) rate, zeroing the calculated VAT on
+		the synced Sales Order. Require distinct tax accounts to avoid this.
+
+		Only the template path produces a calculated tax row; the "Actual" tax type is unaffected
+		(no calculated row exists to be poisoned).
+		"""
+		if int(frappe.__version__.split(".")[0]) < 16:
+			return
+
+		if self.use_actual_tax_type or not self.enable_tax_lines_sync:
+			return
+		if not self.sales_taxes_and_charges_template:
+			return
+
+		template = frappe.get_cached_doc(
+			"Sales Taxes and Charges Template", self.sales_taxes_and_charges_template
+		)
+		template_accounts = {row.account_head for row in template.taxes if row.account_head}
+
+		for fieldname in ("f_n_f_tax_account", "tax_account_for_order_fee_lines"):
+			account = self.get(fieldname)
+			if account and account in template_accounts:
+				frappe.throw(
+					_(
+						"On Frappe v16, '{0}' ({1}) may not re-use a tax account from the Sales Taxes "
+						"and Charges Template '{2}'. Sharing a tax account zeroes the calculated tax on "
+						"synced Sales Orders. Please configure a separate tax account."
+					).format(self.meta.get_label(fieldname), account, self.sales_taxes_and_charges_template)
+				)
 
 	def validate_batch_settings(self):
 		"""

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.py
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.py
@@ -77,7 +77,9 @@ class WooCommerceServer(Document):
 						"On Frappe v16, '{0}' ({1}) may not re-use a tax account from the Sales Taxes "
 						"and Charges Template '{2}'. Sharing a tax account zeroes the calculated tax on "
 						"synced Sales Orders. Please configure a separate tax account."
-					).format(self.meta.get_label(fieldname), account, self.sales_taxes_and_charges_template)
+					).format(
+						_(self.meta.get_label(fieldname)), account, self.sales_taxes_and_charges_template
+					)
 				)
 
 	def validate_batch_settings(self):

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.py
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.py
@@ -41,6 +41,17 @@ class WooCommerceServer(Document):
 		self.validate_so_status_map()
 		self.validate_item_map()
 		self.validate_reserved_stock_setting()
+		self.validate_batch_settings()
+
+	def validate_batch_settings(self):
+		"""
+		Validate Batch API flush interval and batch size limits
+		"""
+		if self.enable_batch_api:
+			if not 1 <= (self.batch_flush_interval_minutes or 1) <= 60:
+				frappe.throw(_("Flush Interval must be between 1 and 60 minutes"))
+			if not 1 <= (self.batch_size_limit or 100) <= 100:
+				frappe.throw(_("Batch Size Limit must be between 1 and 100"))
 
 	def validate_so_status_map(self):
 		"""

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_sync_queue/woocommerce_sync_queue.json
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_sync_queue/woocommerce_sync_queue.json
@@ -1,0 +1,197 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-06-16 00:00:00.000000",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "woocommerce_server",
+  "sync_type",
+  "direction",
+  "wc_resource_type",
+  "status",
+  "column_break_main",
+  "reference_doctype",
+  "reference_name",
+  "woocommerce_id",
+  "parent_woocommerce_id",
+  "item_woocommerce_server_idx",
+  "trigger_section",
+  "triggered_by",
+  "trigger_reference_doctype",
+  "trigger_reference_name",
+  "result_section",
+  "batch_log",
+  "retry_count",
+  "error_message",
+  "extra_data"
+ ],
+ "fields": [
+  {
+   "fieldname": "woocommerce_server",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "WooCommerce Server",
+   "options": "WooCommerce Server",
+   "reqd": 1
+  },
+  {
+   "fieldname": "sync_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Sync Type",
+   "options": "item\nitem_price\nstock\norder",
+   "reqd": 1
+  },
+  {
+   "description": "outbound = ERPNext → WC; inbound = WC → ERPNext. item_price and stock are always outbound.",
+   "fieldname": "direction",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Direction",
+   "options": "outbound\ninbound",
+   "reqd": 1
+  },
+  {
+   "description": "Determines which WC endpoint is called",
+   "fieldname": "wc_resource_type",
+   "fieldtype": "Select",
+   "label": "WC Resource Type",
+   "options": "product\nproduct_variation\norder",
+   "reqd": 1
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Pending\nProcessing\nCompleted\nFailed\nSkipped\nSuperseded"
+  },
+  {
+   "fieldname": "column_break_main",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Reference DocType"
+  },
+  {
+   "description": "item_code for Item rows; WC status string for outbound order rows",
+   "fieldname": "reference_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Reference Name"
+  },
+  {
+   "description": "WC product/order ID at time of enqueue (may be empty for creates)",
+   "fieldname": "woocommerce_id",
+   "fieldtype": "Data",
+   "label": "WooCommerce ID"
+  },
+  {
+   "description": "For product variations: the parent product's WooCommerce ID",
+   "fieldname": "parent_woocommerce_id",
+   "fieldtype": "Data",
+   "label": "Parent WooCommerce ID"
+  },
+  {
+   "description": "idx of the Item WooCommerce Server child row",
+   "fieldname": "item_woocommerce_server_idx",
+   "fieldtype": "Int",
+   "label": "Item WooCommerce Server Row Index"
+  },
+  {
+   "fieldname": "trigger_section",
+   "fieldtype": "Section Break",
+   "label": "Trigger"
+  },
+  {
+   "fieldname": "triggered_by",
+   "fieldtype": "Select",
+   "label": "Triggered By",
+   "options": "Hook\nScheduled\nManual\nBatch Flush"
+  },
+  {
+   "fieldname": "trigger_reference_doctype",
+   "fieldtype": "Data",
+   "label": "Trigger Reference DocType"
+  },
+  {
+   "fieldname": "trigger_reference_name",
+   "fieldtype": "Data",
+   "label": "Trigger Reference Name"
+  },
+  {
+   "fieldname": "result_section",
+   "fieldtype": "Section Break",
+   "label": "Result"
+  },
+  {
+   "fieldname": "batch_log",
+   "fieldtype": "Link",
+   "label": "Batch Log",
+   "options": "WooCommerce Batch Log",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "retry_count",
+   "fieldtype": "Int",
+   "label": "Retry Count"
+  },
+  {
+   "fieldname": "error_message",
+   "fieldtype": "Text",
+   "label": "Error Message",
+   "read_only": 1
+  },
+  {
+   "description": "Pre-computed payload data (e.g. stock_quantity) stored at enqueue time",
+   "fieldname": "extra_data",
+   "fieldtype": "Code",
+   "label": "Extra Data",
+   "options": "JSON"
+  }
+ ],
+ "grid_page_length": 50,
+ "in_create": 1,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-06-16 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "WooCommerce",
+ "name": "WooCommerce Sync Queue",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Stock Manager"
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_sync_queue/woocommerce_sync_queue.py
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_sync_queue/woocommerce_sync_queue.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, Dirk van der Laarse and contributors
+# For license information, please see license.txt
+
+import json
+
+import frappe
+from frappe.model.document import Document
+
+
+class WooCommerceSyncQueue(Document):
+	@staticmethod
+	def clear_old_logs(days=30):
+		"""
+		Called by Frappe's log cleanup scheduler (Log Settings).
+		Only purge terminal rows — Pending and Failed are kept for manual review.
+		"""
+		frappe.db.delete(
+			"WooCommerce Sync Queue",
+			{
+				"status": ["in", ["Completed", "Skipped", "Superseded"]],
+				"modified": ["<", frappe.utils.add_days(None, -days)],
+			},
+		)
+
+
+def _supersede_pending(
+	woocommerce_server: str,
+	sync_type: str,
+	direction: str,
+	filters: dict,
+) -> None:
+	"""
+	Mark any existing Pending row matching the given filters as Superseded so a
+	fresh row can be inserted, preserving full history.
+	"""
+	existing_name = frappe.db.get_value(
+		"WooCommerce Sync Queue",
+		{
+			"woocommerce_server": woocommerce_server,
+			"sync_type": sync_type,
+			"direction": direction,
+			"status": "Pending",
+			**filters,
+		},
+		"name",
+	)
+	if existing_name:
+		frappe.db.set_value(
+			"WooCommerce Sync Queue",
+			existing_name,
+			"status",
+			"Superseded",
+			update_modified=False,
+		)
+
+
+def enqueue_item(
+	woocommerce_server: str,
+	item_code: str,
+	item_woocommerce_server_idx: int,
+	sync_type: str = "item",
+	resource_type: str = "product",
+	parent_woocommerce_id: str | None = None,
+	woocommerce_id: str | None = None,
+	direction: str = "outbound",
+	triggered_by: str = "Hook",
+	trigger_reference_doctype: str | None = None,
+	trigger_reference_name: str | None = None,
+	extra_data: dict | None = None,
+) -> str:
+	"""
+	Add an item/item_price/stock operation to the sync queue. Returns the new queue entry name.
+
+	direction: "outbound" (ERPNext → WC) or "inbound" (WC → ERPNext).
+
+	Deduplicates by (woocommerce_server, reference_name, sync_type, direction): if a Pending
+	row already exists for this combination, it is marked "Superseded" before inserting the new
+	row. This preserves full history — each enqueue event gets its own row.
+	"""
+	_supersede_pending(
+		woocommerce_server,
+		sync_type,
+		direction,
+		{"reference_name": item_code},
+	)
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "WooCommerce Sync Queue",
+			"woocommerce_server": woocommerce_server,
+			"sync_type": sync_type,
+			"direction": direction,
+			"wc_resource_type": resource_type,
+			"woocommerce_id": woocommerce_id,
+			"parent_woocommerce_id": parent_woocommerce_id,
+			"reference_doctype": "Item",
+			"reference_name": item_code,
+			"item_woocommerce_server_idx": item_woocommerce_server_idx,
+			"triggered_by": triggered_by,
+			"trigger_reference_doctype": trigger_reference_doctype,
+			"trigger_reference_name": trigger_reference_name,
+			"extra_data": json.dumps(extra_data) if extra_data else None,
+			"status": "Pending",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def enqueue_order(
+	woocommerce_server: str,
+	woocommerce_order_id: str,
+	new_status: str | None = None,
+	direction: str = "outbound",
+	triggered_by: str = "Hook",
+) -> str:
+	"""
+	Queue an order change. direction = "outbound" (ERPNext → WC) or "inbound" (WC → ERPNext).
+
+	Deduplicates by (woocommerce_server, woocommerce_id, sync_type, direction): if a Pending
+	row exists for the same direction, mark it Superseded and insert a fresh row so the latest
+	status value is always used at flush time. reference_name stores the WC status string for
+	outbound; for inbound it is unused.
+	"""
+	_supersede_pending(
+		woocommerce_server,
+		"order",
+		direction,
+		{"woocommerce_id": woocommerce_order_id},
+	)
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "WooCommerce Sync Queue",
+			"woocommerce_server": woocommerce_server,
+			"sync_type": "order",
+			"direction": direction,
+			"wc_resource_type": "order",
+			"woocommerce_id": woocommerce_order_id,
+			"reference_doctype": "WooCommerce Order",
+			"reference_name": new_status or "",
+			"triggered_by": triggered_by,
+			"status": "Pending",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_sync_queue/woocommerce_sync_queue.py
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_sync_queue/woocommerce_sync_queue.py
@@ -12,7 +12,7 @@ class WooCommerceSyncQueue(Document):
 	def clear_old_logs(days=30):
 		"""
 		Called by Frappe's log cleanup scheduler (Log Settings).
-		Only purge terminal rows — Pending and Failed are kept for manual review.
+		Only purge terminal rows - Pending and Failed are kept for manual review.
 		"""
 		frappe.db.delete(
 			"WooCommerce Sync Queue",
@@ -75,7 +75,7 @@ def enqueue_item(
 
 	Deduplicates by (woocommerce_server, reference_name, sync_type, direction): if a Pending
 	row already exists for this combination, it is marked "Superseded" before inserting the new
-	row. This preserves full history — each enqueue event gets its own row.
+	row. This preserves full history - each enqueue event gets its own row.
 	"""
 	_supersede_pending(
 		woocommerce_server,

--- a/woocommerce_fusion/woocommerce/page/woocommerce_sync_status/woocommerce_sync_status.js
+++ b/woocommerce_fusion/woocommerce/page/woocommerce_sync_status/woocommerce_sync_status.js
@@ -1,0 +1,343 @@
+frappe.pages["woocommerce-sync-status"].on_page_load = function (wrapper) {
+  const page = frappe.ui.make_app_page({
+    parent: wrapper,
+    title: __("WooCommerce Sync Status"),
+    single_column: true,
+  });
+
+  const state = {
+    serverFilter: null,
+    directionFilter: null,
+    autoRefresh: true,
+    pollInterval: null,
+    pendingStart: 0,
+    failedStart: 0,
+    pageLength: 20,
+  };
+
+  page.add_field({
+    fieldname: "server_filter",
+    label: __("WooCommerce Server"),
+    fieldtype: "Link",
+    options: "WooCommerce Server",
+    change() {
+      state.serverFilter = page.fields_dict.server_filter.get_value();
+      resetPaging();
+      refresh();
+    },
+  });
+
+  page.add_field({
+    fieldname: "direction_filter",
+    label: __("Direction"),
+    fieldtype: "Select",
+    options: ["", "inbound", "outbound"].join("\n"),
+    change() {
+      state.directionFilter =
+        page.fields_dict.direction_filter.get_value() || null;
+      resetPaging();
+      refresh();
+    },
+  });
+
+  page.add_menu_item(__("Flush Now"), () => flushNow());
+  page.add_menu_item(__("Retry All Failed"), () => retryAllFailed());
+  page.add_menu_item(__("Toggle Auto-refresh"), () => toggleAutoRefresh());
+  page.set_primary_action(__("Refresh"), () => refresh(), "refresh");
+
+  const $container = $('<div class="wc-sync-status p-3"></div>').appendTo(
+    page.main,
+  );
+
+  const STATUS_COLORS = {
+    Pending: "orange",
+    Processing: "blue",
+    Completed: "green",
+    Failed: "red",
+    Skipped: "gray",
+    Superseded: "gray",
+    Partial: "orange",
+  };
+
+  function resetPaging() {
+    state.pendingStart = 0;
+    state.failedStart = 0;
+  }
+
+  function badge(value) {
+    const color = STATUS_COLORS[value] || "gray";
+    return `<span class="indicator-pill ${color}">${frappe.utils.escape_html(
+      value || "",
+    )}</span>`;
+  }
+
+  function recordLink(doctype, name) {
+    if (!doctype || !name) return frappe.utils.escape_html(name || "");
+    return `<a href="/app/${frappe.router.slug(doctype)}/${encodeURIComponent(
+      name,
+    )}">${frappe.utils.escape_html(name)}</a>`;
+  }
+
+  // Inbound rows have no ERPNext document yet, so fall back to the WooCommerce id.
+  function referenceCell(r) {
+    if (r.reference_doctype === "Item" && r.reference_name) {
+      return recordLink(r.reference_doctype, r.reference_name);
+    }
+    if (r.woocommerce_id) {
+      return `<span class="text-muted">WC #${frappe.utils.escape_html(
+        r.woocommerce_id,
+      )}</span>`;
+    }
+    if (r.reference_name) return frappe.utils.escape_html(r.reference_name);
+    return "";
+  }
+
+  function renderServerCards(data) {
+    if (!data.servers.length) return "";
+    const cards = data.servers
+      .map((server) => {
+        const rows = data.queue_summary.filter(
+          (r) => r.woocommerce_server === server.name,
+        );
+        const counts = {};
+        rows.forEach((r) => {
+          counts[r.status] = (counts[r.status] || 0) + r.count;
+        });
+        const stat = (label) =>
+          `<div>${label}: <b>${counts[label] || 0}</b></div>`;
+        const total = Object.values(counts).reduce((a, b) => a + b, 0);
+        const failed = counts["Failed"] || 0;
+        const failureRate = total ? failed / total : 0;
+        const failureBadge =
+          failureRate > 0.1
+            ? `<span class="indicator-pill red">${(failureRate * 100).toFixed(
+                0,
+              )}% failed</span>`
+            : "";
+        return `
+				<div class="col-md-4 mb-3">
+					<div class="card p-3">
+						<h6>${frappe.utils.escape_html(server.name)} ${
+              server.enable_batch_api ? badge("Batch") : ""
+            } ${failureBadge}</h6>
+						${stat("Pending")}
+						${stat("Failed")}
+						${stat("Completed")}
+						<div class="text-muted small mt-2">
+							Flush: ${server.batch_flush_interval_minutes || "-"} min /
+							size ${server.batch_size_limit || "-"}
+						</div>
+					</div>
+				</div>`;
+      })
+      .join("");
+    return `<div class="row">${cards}</div>`;
+  }
+
+  function renderPager(pager) {
+    if (!pager) return "";
+    const { kind, start, total, pageLength } = pager;
+    const from = total ? start + 1 : 0;
+    const to = Math.min(start + pageLength, total);
+    return `
+		<div class="d-flex justify-content-between align-items-center mb-3">
+			<span class="text-muted small">${__("Showing")} ${from}–${to} ${__(
+        "of",
+      )} ${total}</span>
+			<span>
+				<button class="btn btn-xs btn-default wc-pager" data-kind="${kind}" data-dir="prev" ${
+          start <= 0 ? "disabled" : ""
+        }>${__("Prev")}</button>
+				<button class="btn btn-xs btn-default wc-pager" data-kind="${kind}" data-dir="next" ${
+          to >= total ? "disabled" : ""
+        }>${__("Next")}</button>
+			</span>
+		</div>`;
+  }
+
+  function renderTable(title, rows, columns, rowFn, pager) {
+    const head = columns.map((c) => `<th>${__(c)}</th>`).join("");
+    const body = rows.length
+      ? rows.map(rowFn).join("")
+      : `<tr><td colspan="${
+          columns.length
+        }" class="text-muted text-center">${__("None")}</td></tr>`;
+    const count = pager ? pager.total : rows.length;
+    return `
+		<h5 class="mt-4">${__(title)} <span class="text-muted">(${count})</span></h5>
+		<table class="table table-bordered table-sm">
+			<thead><tr>${head}</tr></thead>
+			<tbody>${body}</tbody>
+		</table>
+		${renderPager(pager)}`;
+  }
+
+  function render(data) {
+    let html = renderServerCards(data);
+
+    html += renderTable(
+      "Pending Queue",
+      data.pending_items,
+      [
+        "Server",
+        "Sync Type",
+        "Direction",
+        "Reference",
+        "Triggered By",
+        "Queued At",
+      ],
+      (r) => `<tr>
+				<td>${frappe.utils.escape_html(r.woocommerce_server)}</td>
+				<td>${frappe.utils.escape_html(r.sync_type)}</td>
+				<td>${frappe.utils.escape_html(r.direction)}</td>
+				<td>${referenceCell(r)}</td>
+				<td>${frappe.utils.escape_html(r.triggered_by || "")}</td>
+				<td>${frappe.datetime.comment_when(r.creation)}</td>
+			</tr>`,
+      {
+        kind: "pending",
+        start: data.pending_start,
+        total: data.pending_total,
+        pageLength: data.page_length,
+      },
+    );
+
+    html += renderTable(
+      "Recent Batches",
+      data.batch_logs,
+      ["Server", "Resource", "Status", "Total", "Success", "Failed", "Flushed"],
+      (r) => `<tr>
+				<td>${frappe.utils.escape_html(r.woocommerce_server)}</td>
+				<td>${frappe.utils.escape_html(r.resource_type || "")}</td>
+				<td>${badge(r.status)}</td>
+				<td>${r.total_items || 0}</td>
+				<td>${r.successful_items || 0}</td>
+				<td>${r.failed_items || 0}</td>
+				<td>${r.flushed_at ? frappe.datetime.comment_when(r.flushed_at) : ""}</td>
+			</tr>`,
+    );
+
+    html += renderTable(
+      "Failed Entries",
+      data.failed_items,
+      ["Server", "Sync Type", "Direction", "Reference", "Error", "Actions"],
+      (r) => `<tr>
+				<td>${frappe.utils.escape_html(r.woocommerce_server)}</td>
+				<td>${frappe.utils.escape_html(r.sync_type)}</td>
+				<td>${frappe.utils.escape_html(r.direction)}</td>
+				<td>${referenceCell(r)}</td>
+				<td class="small text-danger">${frappe.utils.escape_html(
+          (r.error_message || "").slice(0, 200),
+        )}</td>
+				<td><button class="btn btn-xs btn-default wc-retry" data-name="${frappe.utils.escape_html(
+          r.name,
+        )}">${__("Retry")}</button></td>
+			</tr>`,
+      {
+        kind: "failed",
+        start: data.failed_start,
+        total: data.failed_total,
+        pageLength: data.page_length,
+      },
+    );
+
+    $container.html(html);
+    $container.find(".wc-retry").on("click", function () {
+      retryEntry($(this).data("name"));
+    });
+    $container.find(".wc-pager").on("click", function () {
+      const kind = $(this).data("kind");
+      const dir = $(this).data("dir");
+      const key = kind === "pending" ? "pendingStart" : "failedStart";
+      const delta = dir === "next" ? state.pageLength : -state.pageLength;
+      state[key] = Math.max(0, state[key] + delta);
+      refresh();
+    });
+  }
+
+  function refresh() {
+    frappe
+      .call({
+        method:
+          "woocommerce_fusion.woocommerce.page.woocommerce_sync_status.woocommerce_sync_status.get_dashboard_data",
+        args: {
+          server_name: state.serverFilter || null,
+          direction: state.directionFilter || null,
+          pending_start: state.pendingStart,
+          failed_start: state.failedStart,
+          page_length: state.pageLength,
+        },
+      })
+      .then((r) => {
+        if (r.message) render(r.message);
+      });
+  }
+
+  function flushNow() {
+    if (!state.serverFilter) {
+      frappe.msgprint(__("Select a WooCommerce Server first"));
+      return;
+    }
+    frappe
+      .call({
+        method: "woocommerce_fusion.tasks.batch.queue_manager.manual_flush",
+        args: { server_name: state.serverFilter },
+      })
+      .then(() => {
+        frappe.show_alert({
+          message: __("Flush triggered"),
+          indicator: "green",
+        });
+        refresh();
+      });
+  }
+
+  function retryAllFailed() {
+    frappe
+      .call({
+        method:
+          "woocommerce_fusion.woocommerce.page.woocommerce_sync_status.woocommerce_sync_status.retry_all_failed",
+        args: { server_name: state.serverFilter || null },
+      })
+      .then(() => {
+        frappe.show_alert({
+          message: __("All failed entries reset to Pending"),
+          indicator: "green",
+        });
+        resetPaging();
+        refresh();
+      });
+  }
+
+  function retryEntry(name) {
+    frappe
+      .call({
+        method:
+          "woocommerce_fusion.woocommerce.page.woocommerce_sync_status.woocommerce_sync_status.retry_failed",
+        args: { queue_entry_name: name },
+      })
+      .then(() => refresh());
+  }
+
+  function startPolling() {
+    clearInterval(state.pollInterval);
+    if (state.autoRefresh) {
+      state.pollInterval = setInterval(refresh, 30000);
+    }
+  }
+
+  function toggleAutoRefresh() {
+    state.autoRefresh = !state.autoRefresh;
+    frappe.show_alert({
+      message: state.autoRefresh
+        ? __("Auto-refresh on")
+        : __("Auto-refresh off"),
+      indicator: state.autoRefresh ? "green" : "orange",
+    });
+    startPolling();
+  }
+
+  refresh();
+  startPolling();
+  $(wrapper).on("hide", () => clearInterval(state.pollInterval));
+};

--- a/woocommerce_fusion/woocommerce/page/woocommerce_sync_status/woocommerce_sync_status.json
+++ b/woocommerce_fusion/woocommerce/page/woocommerce_sync_status/woocommerce_sync_status.json
@@ -1,0 +1,24 @@
+{
+ "content": null,
+ "creation": "2026-06-16 00:00:00.000000",
+ "doctype": "Page",
+ "idx": 0,
+ "modified": "2026-06-16 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "WooCommerce",
+ "name": "woocommerce-sync-status",
+ "owner": "Administrator",
+ "page_name": "woocommerce-sync-status",
+ "roles": [
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "Stock Manager"
+  }
+ ],
+ "script": null,
+ "standard": "Yes",
+ "style": null,
+ "title": "WooCommerce Sync Status"
+}

--- a/woocommerce_fusion/woocommerce/page/woocommerce_sync_status/woocommerce_sync_status.py
+++ b/woocommerce_fusion/woocommerce/page/woocommerce_sync_status/woocommerce_sync_status.py
@@ -23,7 +23,7 @@ def get_dashboard_data(
 	if direction:
 		row_filters["direction"] = direction
 
-	# Queue summary by (status, direction, sync_type) — covers both inbound and outbound
+	# Queue summary by (status, direction, sync_type) - covers both inbound and outbound
 	queue_summary = frappe.db.get_all(
 		"WooCommerce Sync Queue",
 		filters=filters,

--- a/woocommerce_fusion/woocommerce/page/woocommerce_sync_status/woocommerce_sync_status.py
+++ b/woocommerce_fusion/woocommerce/page/woocommerce_sync_status/woocommerce_sync_status.py
@@ -1,0 +1,160 @@
+import frappe
+
+
+@frappe.whitelist()
+def get_dashboard_data(
+	server_name: str | None = None,
+	direction: str | None = None,
+	pending_start: int = 0,
+	failed_start: int = 0,
+	page_length: int = 20,
+) -> dict:
+	"""Returns all data needed to render the sync status dashboard."""
+	pending_start = int(pending_start)
+	failed_start = int(failed_start)
+	page_length = int(page_length)
+
+	filters = {}
+	if server_name:
+		filters["woocommerce_server"] = server_name
+
+	# Direction only narrows the pending/failed tables, not the per-server summary counts.
+	row_filters = {**filters}
+	if direction:
+		row_filters["direction"] = direction
+
+	# Queue summary by (status, direction, sync_type) — covers both inbound and outbound
+	queue_summary = frappe.db.get_all(
+		"WooCommerce Sync Queue",
+		filters=filters,
+		fields=[
+			"status",
+			"direction",
+			"sync_type",
+			"woocommerce_server",
+			"count(name) as count",
+			"min(creation) as oldest",
+		],
+		group_by="status, direction, sync_type, woocommerce_server",
+		order_by="woocommerce_server, direction, sync_type, status",
+	)
+
+	pending_filters = {**row_filters, "status": "Pending"}
+	pending_total = frappe.db.count("WooCommerce Sync Queue", pending_filters)
+	pending_items = frappe.get_all(
+		"WooCommerce Sync Queue",
+		filters=pending_filters,
+		fields=[
+			"name",
+			"woocommerce_server",
+			"sync_type",
+			"direction",
+			"wc_resource_type",
+			"woocommerce_id",
+			"reference_doctype",
+			"reference_name",
+			"triggered_by",
+			"trigger_reference_doctype",
+			"trigger_reference_name",
+			"creation",
+		],
+		order_by="creation asc",
+		limit_start=pending_start,
+		limit_page_length=page_length,
+	)
+
+	failed_filters = {**row_filters, "status": "Failed"}
+	failed_total = frappe.db.count("WooCommerce Sync Queue", failed_filters)
+	failed_items = frappe.get_all(
+		"WooCommerce Sync Queue",
+		filters=failed_filters,
+		fields=[
+			"name",
+			"woocommerce_server",
+			"sync_type",
+			"direction",
+			"wc_resource_type",
+			"woocommerce_id",
+			"reference_doctype",
+			"reference_name",
+			"triggered_by",
+			"error_message",
+			"batch_log",
+			"creation",
+		],
+		order_by="modified desc",
+		limit_start=failed_start,
+		limit_page_length=page_length,
+	)
+
+	batch_logs = frappe.get_all(
+		"WooCommerce Batch Log",
+		filters=filters,
+		fields=[
+			"name",
+			"woocommerce_server",
+			"resource_type",
+			"status",
+			"total_items",
+			"successful_items",
+			"failed_items",
+			"flush_reason",
+			"flushed_at",
+		],
+		order_by="flushed_at desc",
+		limit=20,
+	)
+
+	servers = frappe.get_all(
+		"WooCommerce Server",
+		filters={"enable_sync": 1},
+		fields=[
+			"name",
+			"enable_batch_api",
+			"batch_flush_interval_minutes",
+			"batch_size_limit",
+			"woocommerce_server_url",
+		],
+	)
+
+	return {
+		"queue_summary": queue_summary,
+		"pending_items": pending_items,
+		"pending_total": pending_total,
+		"pending_start": pending_start,
+		"failed_items": failed_items,
+		"failed_total": failed_total,
+		"failed_start": failed_start,
+		"page_length": page_length,
+		"batch_logs": batch_logs,
+		"servers": servers,
+	}
+
+
+@frappe.whitelist()
+def retry_failed(queue_entry_name: str):
+	"""Reset a failed queue entry back to Pending for retry."""
+	retry_count = frappe.db.get_value("WooCommerce Sync Queue", queue_entry_name, "retry_count") or 0
+	frappe.db.set_value(
+		"WooCommerce Sync Queue",
+		queue_entry_name,
+		{
+			"status": "Pending",
+			"error_message": "",
+			"batch_log": None,
+			"retry_count": retry_count + 1,
+		},
+	)
+
+
+@frappe.whitelist()
+def retry_all_failed(server_name: str | None = None):
+	"""Reset all Failed entries for a server back to Pending."""
+	filters = {"status": "Failed"}
+	if server_name:
+		filters["woocommerce_server"] = server_name
+	frappe.db.set_value(
+		"WooCommerce Sync Queue",
+		filters,
+		{"status": "Pending", "error_message": "", "batch_log": None},
+	)

--- a/woocommerce_fusion/woocommerce/woocommerce_api.py
+++ b/woocommerce_fusion/woocommerce/woocommerce_api.py
@@ -13,6 +13,12 @@ from woocommerce_fusion.tasks.utils import APIWithRequestLogging
 
 WC_RESOURCE_DELIMITER = "~"
 
+# Appended to "unsupported filter" errors so users know they can request it.
+REQUEST_FILTER_FEATURE_MESSAGE = (
+	"If you need this filter, please request it "
+	'<a href="https://github.com/Starktail/woocommerce_fusion/issues" target="_blank">here</a>.'
+)
+
 verify_ssl = not frappe._dev_server
 
 if frappe._dev_server:
@@ -163,9 +169,11 @@ class WooCommerceResource(Document):
 			params["per_page"] = min(per_page + offset, wc_records_per_page_limit)
 
 			# Map Frappe filters to WooCommerce parameters
+			filter_servers = None
 			if args.get("filters"):
-				updated_params = get_wc_parameters_from_filters(args["filters"])
+				updated_params = get_wc_parameters_from_filters(args["filters"], cls.field_setter_map)
 				params.update(updated_params)
+				filter_servers = get_woocommerce_servers_from_filters(args["filters"])
 
 			# Initialse required variables
 			all_results = []
@@ -176,6 +184,9 @@ class WooCommerceResource(Document):
 				if args.get("servers", None):
 					if wc_server.woocommerce_server not in args["servers"]:
 						continue
+				# Skip servers not targeted by a name / woocommerce_server filter
+				if filter_servers and wc_server.woocommerce_server not in filter_servers:
+					continue
 
 				current_offset = 0
 
@@ -540,7 +551,7 @@ def generate_woocommerce_record_name_from_domain_and_id(
 	return f"{domain}{delimiter}{resource_id}"
 
 
-def get_wc_parameters_from_filters(filters):
+def get_wc_parameters_from_filters(filters, field_setter_map=None):
 	"""
 	http://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-orders
 	https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-products
@@ -558,17 +569,22 @@ def get_wc_parameters_from_filters(filters):
 	params = {}
 
 	for filter in filters:
-		if filter[1] not in supported_filter_fields:
-			frappe.throw(f"Unsupported filter for field: {filter[1]}")
-		if filter[1] == "date_created" and filter[2] == "<":
+		# Normalise field aliases (e.g. Product's "woocommerce_id" -> "id") via field_setter_map.
+		field = filter[1]
+		if field_setter_map and field in field_setter_map:
+			field = field_setter_map[field]
+
+		if field not in supported_filter_fields:
+			frappe.throw(f"Unsupported filter for field: {filter[1]}\n\n{REQUEST_FILTER_FEATURE_MESSAGE}")
+		if field == "date_created" and filter[2] == "<":
 			# e.g. ['WooCommerce Order', 'date_created', '<', '2023-01-01']
 			params["before"] = filter[3]
 			continue
-		if filter[1] == "date_created" and filter[2] == ">":
+		if field == "date_created" and filter[2] == ">":
 			# e.g. ['WooCommerce Order', 'date_created', '>', '2023-01-01']
 			params["after"] = filter[3]
 			continue
-		if filter[1] == "date_created" and filter[2] == "Between":
+		if field == "date_created" and filter[2] == "Between":
 			# e.g. ['WooCommerce Order', 'date_created', 'Between', '[2023-01-01, 2023-01-20]']
 			if not filter[3]:
 				continue
@@ -577,15 +593,15 @@ def get_wc_parameters_from_filters(filters):
 				get_datetime(f"{filter[3][1]} 00:00:00"), "yyyy-MM-dd HH:mm:ss"
 			)
 			continue
-		if filter[1] == "date_modified" and filter[2] == "<":
+		if field == "date_modified" and filter[2] == "<":
 			# e.g. ['WooCommerce Order', 'date_modified', '<', '2023-01-01']
 			params["modified_before"] = filter[3]
 			continue
-		if filter[1] == "date_modified" and filter[2] == ">":
+		if field == "date_modified" and filter[2] == ">":
 			# e.g. ['WooCommerce Order', 'date_modified', '>', '2023-01-01']
 			params["modified_after"] = filter[3]
 			continue
-		if filter[1] == "date_modified" and filter[2] == "Between":
+		if field == "date_modified" and filter[2] == "Between":
 			# e.g. ['WooCommerce Order', 'date_created', 'Between', '[2023-01-01, 2023-01-20]']
 			if not filter[3]:
 				continue
@@ -594,29 +610,75 @@ def get_wc_parameters_from_filters(filters):
 				get_datetime(f"{filter[3][1]} 00:00:00"), "yyyy-MM-dd HH:mm:ss"
 			)
 			continue
-		if filter[1] == "id" and filter[2] == "=":
+		if field == "id" and filter[2] == "=":
 			# e.g. ['WooCommerce Order', 'id', '=', '11']
 			params["include"] = [filter[3]]
 			continue
-		if filter[1] == "id" and filter[2] == "in":
+		if field == "id" and filter[2] == "in":
 			# e.g. ['WooCommerce Order', 'id', 'in', ['11', '12', '13']]
 			params["include"] = ",".join(filter[3])
 			continue
-		if filter[1] == "name" and filter[2] == "like":
+		if field == "name" and filter[2] == "=":
+			# name is the document id '<domain>~<id>'; filter the API by the WooCommerce id.
+			# e.g. ['WooCommerce Order', 'name', '=', 'woo-test.localhost~75']
+			value = filter[3]
+			if WC_RESOURCE_DELIMITER in value:
+				_domain, resource_id = get_domain_and_id_from_woocommerce_record_name(value)
+			else:
+				resource_id = value
+			params["include"] = [resource_id]
+			continue
+		if field == "name" and filter[2] == "in":
+			# e.g. ['WooCommerce Order', 'name', 'in', ['woo-test.localhost~75', 'woo-test.localhost~76']]
+			resource_ids = [
+				get_domain_and_id_from_woocommerce_record_name(value)[1]
+				if WC_RESOURCE_DELIMITER in value
+				else value
+				for value in filter[3]
+			]
+			params["include"] = ",".join(str(resource_id) for resource_id in resource_ids)
+			continue
+		if field == "name" and filter[2] == "like":
 			# e.g. ['WooCommerce Order', 'name', 'like', '%11%']
 			params["search"] = filter[3].strip("%")
 			continue
-		if filter[1] == "customer_id" and filter[2] == "like":
+		if field == "customer_id" and filter[2] == "like":
 			# e.g. ['WooCommerce Order', 'customer_id', 'like', '%11%']
 			params["search"] = filter[3].strip("%")
 			continue
-		if filter[1] == "status" and filter[2] == "=":
+		if field == "status" and filter[2] == "=":
 			# e.g. ['WooCommerce Order', 'status', '=', 'trash']
 			params["status"] = filter[3]
 			continue
-		frappe.throw(f"Unsupported filter '{filter[2]}' for field '{filter[1]}'")
+		if field == "woocommerce_server":
+			# Scopes the query to a server (see get_woocommerce_servers_from_filters), not a WC param.
+			continue
+		frappe.throw(
+			f"Unsupported filter '{filter[2]}' for field '{filter[1]}'\n\n{REQUEST_FILTER_FEATURE_MESSAGE}"
+		)
 
 	return params
+
+
+def get_woocommerce_servers_from_filters(filters):
+	"""
+	Return the server name(s) the filters are scoped to (from a 'name' or 'woocommerce_server'
+	filter), or None. Used so a 'name =' filter only queries the matching server.
+	"""
+	servers = set()
+	for filter in filters:
+		field, operator, value = filter[1], filter[2], filter[3]
+		if field == "name" and operator == "=" and isinstance(value, str) and WC_RESOURCE_DELIMITER in value:
+			servers.add(get_domain_and_id_from_woocommerce_record_name(value)[0])
+		elif field == "name" and operator == "in":
+			servers.update(
+				get_domain_and_id_from_woocommerce_record_name(v)[0]
+				for v in value
+				if isinstance(v, str) and WC_RESOURCE_DELIMITER in v
+			)
+		elif field == "woocommerce_server" and operator == "=":
+			servers.add(value)
+	return servers or None
 
 
 def log_and_raise_error(exception=None, error_text=None, response=None):

--- a/woocommerce_fusion/woocommerce/woocommerce_api.py
+++ b/woocommerce_fusion/woocommerce/woocommerce_api.py
@@ -286,6 +286,45 @@ class WooCommerceResource(Document):
 	def get_stats(args):
 		pass
 
+	@classmethod
+	def batch_update(
+		cls,
+		server_name: str,
+		payload: dict,
+		parent_id: str | None = None,
+	) -> dict:
+		"""
+		Execute a batch create/update/delete against the WooCommerce batch endpoint.
+
+		Args:
+			server_name: Name of the WooCommerce Server doc
+			payload: Dict with keys 'create', 'update', 'delete' (any subset)
+			parent_id: For child resources (e.g. variations), the parent's WooCommerce ID
+
+		Returns:
+			Parsed JSON response dict from WooCommerce
+		"""
+		wc_api_list = cls._init_api()
+		wc_api = next((api for api in wc_api_list if api.woocommerce_server == server_name), None)
+		if not wc_api:
+			frappe.throw(_("WooCommerce Server {0} not found or not enabled").format(server_name))
+
+		endpoint = (
+			f"{cls.resource}/{parent_id}/{cls.child_resource}/batch"
+			if parent_id and cls.child_resource
+			else f"{cls.resource}/batch"
+		)
+
+		try:
+			response = wc_api.api.post(endpoint, data=payload)
+		except Exception as err:
+			log_and_raise_error(err, error_text="batch_update failed")
+
+		if response.status_code not in (200, 201):
+			log_and_raise_error(error_text="batch_update failed", response=response)
+
+		return response.json()
+
 	def db_insert(self, *args, **kwargs):
 		"""
 		Creates a new WooCommerce Record

--- a/woocommerce_fusion/woocommerce_endpoint.py
+++ b/woocommerce_fusion/woocommerce_endpoint.py
@@ -58,10 +58,22 @@ def order_created(*args, **kwargs):
 
 	if event == "created":
 		webhook_source_url = frappe.get_request_header("x-wc-webhook-source", "")
-		woocommerce_order_name = (
-			f"{parse_domain_from_url(webhook_source_url)}{WC_RESOURCE_DELIMITER}{order['id']}"
-		)
-		frappe.enqueue(run_sales_order_sync, queue="long", woocommerce_order_name=woocommerce_order_name)
+		server_domain = parse_domain_from_url(webhook_source_url)
+		woocommerce_order_name = f"{server_domain}{WC_RESOURCE_DELIMITER}{order['id']}"
+		server = frappe.get_cached_doc("WooCommerce Server", server_domain)
+		if server.enable_batch_api:
+			from woocommerce_fusion.woocommerce.doctype.woocommerce_sync_queue.woocommerce_sync_queue import (
+				enqueue_order,
+			)
+
+			enqueue_order(
+				woocommerce_server=server_domain,
+				woocommerce_order_id=str(order["id"]),
+				direction="inbound",
+				triggered_by="Hook",
+			)
+		else:
+			frappe.enqueue(run_sales_order_sync, queue="long", woocommerce_order_name=woocommerce_order_name)
 		return Response(status=HTTPStatus.OK)
 	else:
 		return Response(response=_("Event not supported"), status=HTTPStatus.BAD_REQUEST)


### PR DESCRIPTION
## Description

- feat: batch api mode for improved perf
- feat: Don't create a Sales Order for an order that is trashed
- feat: WooCommerce order number for autonaming
    - Fixes https://github.com/Starktail/woocommerce_fusion/issues/247
- fix: Improved checkbox label
    - Fixes #226
- feat: official v16 compatibility
    - Fixes https://github.com/Starktail/woocommerce_fusion/issues/244
- fix: do not change woo order status if setting is disabled
    - Fixes https://github.com/Starktail/woocommerce_fusion/issues/218
- feat: add support for more filters 
    - Fixes https://github.com/Starktail/woocommerce_fusion/issues/220



## Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Tests

- [x] [Unit Tests](https://frappeframework.com/docs/user/en/guides/automated-testing/unit-testing) have been updated or added, as required
- [ ] [UI Tests](https://frappeframework.com/docs/user/en/ui-testing) have been updated or added, as required

## Checklist:

- [x] My code follows [Naming Guidelines](https://github.com/frappe/erpnext/wiki/Naming-Guidelines) (DocType, Field  and Variable naming)
- [x] No Form changes */* My code follows the [Form Design Guidelines](https://github.com/frappe/erpnext/wiki/Form-Design-Guidelines)
- [x] My code follows the [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards) of this project
- [x] My code follows the [Code Security Guidelines](https://github.com/frappe/erpnext/wiki/Code-Security-Guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas */* No comments necessary
- [ ] I have made corresponding additions/changes to the documentation
- [x] All business logic and validations are on the server-side */* No business logic or validation changes
- [x] No patches are necessary */* Migration Patches have been added to the correct subdirectory of `/patches` and `patches.txt` have been updated


## User Experience:

TBC
