### PR TITLE
feat: optionally publish quantities and prices in the Item's Sales UOM

### DIFF
--- a/woocommerce_fusion/tasks/stock_update.py
+++ b/woocommerce_fusion/tasks/stock_update.py
@@ -2,7 +2,10 @@ import math
 
 import frappe
 
-from woocommerce_fusion.tasks.utils import APIWithRequestLogging
+from woocommerce_fusion.tasks.utils import (
+	APIWithRequestLogging,
+	get_sales_uom_conversion_factor,
+)
 
 verify_ssl = not frappe._dev_server
 
@@ -116,19 +119,27 @@ def update_stock_levels_on_woocommerce_site(item_code: str):
 					verify_ssl=verify_ssl,
 				)
 
-				# Sum all quantities from select warehouses and round the total down (WooCommerce API doesn't accept float values)
+				# Sum all quantities from select warehouses
+				qty_in_stock_uom = sum(
+					bin.actual_qty
+					if not wc_server.subtract_reserved_stock
+					else bin.actual_qty - bin.reserved_qty
+					for bin in bins
+					if bin.warehouse in [row.warehouse for row in wc_server.warehouses]
+				)
+
+				# Convert to the Item's Sales UOM when the server is set up for it.
+				# Without this, a shop that sells by the box would advertise the
+				# number of individual pieces: 52900 instead of 52.
+				conversion_factor = (
+					get_sales_uom_conversion_factor(item_code) if wc_server.sync_in_sales_uom else 1.0
+				)
+
+				# Round the total down (WooCommerce API doesn't accept float values)
 				data_to_post = {
 					"stock_quantity": 0
 					if item.disabled
-					else math.floor(
-						sum(
-							bin.actual_qty
-							if not wc_server.subtract_reserved_stock
-							else bin.actual_qty - bin.reserved_qty
-							for bin in bins
-							if bin.warehouse in [row.warehouse for row in wc_server.warehouses]
-						)
-					)
+					else math.floor(qty_in_stock_uom / conversion_factor)
 				}
 
 				try:

--- a/woocommerce_fusion/tasks/sync_items.py
+++ b/woocommerce_fusion/tasks/sync_items.py
@@ -983,15 +983,21 @@ def get_item_price_rate(item: ERPNextItemToSync):
 	"""
 	wc_server = frappe.get_cached_doc("WooCommerce Server", item.item_woocommerce_server.woocommerce_server)
 	if wc_server.enable_price_list_sync:
+		filters = {
+			"item_code": item.item.item_code,
+			"price_list": wc_server.price_list,
+			"batch_no": ("is", "not set"),
+			"customer": ("is", "not set"),
+			"supplier": ("is", "not set"),
+		}
+		# When quantities are published in the Sales UOM, the price has to be the
+		# price of that same unit, or the shop shows a per-piece price against a
+		# per-box quantity.
+		if wc_server.sync_in_sales_uom and item.item.sales_uom:
+			filters["uom"] = item.item.sales_uom
 		item_prices = frappe.get_all(
 			"Item Price",
-			filters={
-				"item_code": item.item.item_code,
-				"price_list": wc_server.price_list,
-				"batch_no": ("is", "not set"),
-				"customer": ("is", "not set"),
-				"supplier": ("is", "not set"),
-			},
+			filters=filters,
 			fields=["price_list_rate", "valid_upto"],
 		)
 		return next(

--- a/woocommerce_fusion/tasks/test_stock_update.py
+++ b/woocommerce_fusion/tasks/test_stock_update.py
@@ -230,3 +230,52 @@ class TestWooCommerceStockSync(FrappeTestCase):
 		update_stock_levels_for_all_enabled_items_in_background()
 
 		self.assertEqual(mock_get_all.call_args.kwargs["filters"], {})
+
+
+class TestUOMConversion(FrappeTestCase):
+	"""Tests for `sync_in_sales_uom`: publishing quantities in the Sales UOM.
+
+	A distributor may keep stock in Pieces and sell in Boxes of 1000. Without
+	the conversion the shop advertises 52900 items where there are 52 boxes.
+	"""
+
+	def test_conversion_factor_is_one_without_a_sales_uom(self):
+		"""No Sales UOM means nothing changes: the common case stays a no-op."""
+		item = frappe._dict(sales_uom=None, stock_uom="Nos", uoms=[])
+		with patch("woocommerce_fusion.tasks.utils.frappe.get_cached_doc", return_value=item):
+			from woocommerce_fusion.tasks.utils import get_sales_uom_conversion_factor
+
+			self.assertEqual(get_sales_uom_conversion_factor("ITEM-1"), 1.0)
+
+	def test_conversion_factor_is_one_when_sales_uom_equals_stock_uom(self):
+		item = frappe._dict(sales_uom="Nos", stock_uom="Nos", uoms=[])
+		with patch("woocommerce_fusion.tasks.utils.frappe.get_cached_doc", return_value=item):
+			from woocommerce_fusion.tasks.utils import get_sales_uom_conversion_factor
+
+			self.assertEqual(get_sales_uom_conversion_factor("ITEM-1"), 1.0)
+
+	def test_conversion_factor_is_read_from_the_item(self):
+		item = frappe._dict(
+			sales_uom="Box",
+			stock_uom="Piece",
+			uoms=[
+				frappe._dict(uom="Piece", conversion_factor=1),
+				frappe._dict(uom="Box", conversion_factor=1000),
+			],
+		)
+		with patch("woocommerce_fusion.tasks.utils.frappe.get_cached_doc", return_value=item):
+			from woocommerce_fusion.tasks.utils import get_sales_uom_conversion_factor
+
+			self.assertEqual(get_sales_uom_conversion_factor("ITEM-1"), 1000.0)
+
+	def test_conversion_factor_is_one_when_the_sales_uom_has_no_conversion(self):
+		"""A Sales UOM that is not in the conversion table must not break the sync."""
+		item = frappe._dict(
+			sales_uom="Box",
+			stock_uom="Piece",
+			uoms=[frappe._dict(uom="Piece", conversion_factor=1)],
+		)
+		with patch("woocommerce_fusion.tasks.utils.frappe.get_cached_doc", return_value=item):
+			from woocommerce_fusion.tasks.utils import get_sales_uom_conversion_factor
+
+			self.assertEqual(get_sales_uom_conversion_factor("ITEM-1"), 1.0)

--- a/woocommerce_fusion/tasks/utils.py
+++ b/woocommerce_fusion/tasks/utils.py
@@ -2,8 +2,30 @@ import traceback
 
 import frappe
 import requests
+from frappe.utils import flt
 from frappe.utils.caching import redis_cache
 from woocommerce import API
+
+
+def get_sales_uom_conversion_factor(item_code: str) -> float:
+	"""Return how many Stock UOM units make up one Sales UOM unit for an Item.
+
+	Returns 1.0 when the Item has no Sales UOM, when it is the same as the Stock
+	UOM, or when no conversion is defined for it. That keeps callers a no-op for
+	the common case where a shop sells in the same unit the stock is kept in.
+
+	Example: an Item kept in "Piece" and sold in "Box" of 1000 returns 1000.0,
+	so 52900 pieces in stock become 52 boxes available in the shop.
+	"""
+	item = frappe.get_cached_doc("Item", item_code)
+	if not item.sales_uom or item.sales_uom == item.stock_uom:
+		return 1.0
+
+	for row in item.uoms:
+		if row.uom == item.sales_uom:
+			return flt(row.conversion_factor) or 1.0
+
+	return 1.0
 
 
 class APIWithRequestLogging(API):

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.json
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.json
@@ -417,6 +417,14 @@
    "label": "Sync stock levels from ERPNext to WooCommerce (1-way)"
   },
   {
+   "default": "0",
+   "depends_on": "eval:doc.enable_stock_level_synchronisation || doc.enable_price_list_sync",
+   "description": "Publish quantities and prices in the Item's Sales UOM instead of its Stock UOM. Use this when you keep stock in one unit and sell in another, e.g. stock in Pieces and sales in Boxes of 1000: with this off the shop would advertise 52900 items instead of 52 boxes.",
+   "fieldname": "sync_in_sales_uom",
+   "fieldtype": "Check",
+   "label": "Synchronise in the Item's Sales UOM"
+  },
+  {
    "default": "WooCommerce ID",
    "description": "How the item code should be determined when an item is created",
    "fieldname": "name_by",


### PR DESCRIPTION
## Description

When a shop sells in a different unit than the one stock is kept in, the sync currently
publishes mismatched data: the **quantity** comes from the Stock UOM while the **price** may
belong to the Sales UOM.

Concrete case — a distributor keeping stock in `Piece` and selling in `Box` of 1000:

| | ERPNext | Published to WooCommerce |
|---|---|---|
| Stock | 52,900 pieces = **52.9 boxes** | `stock_quantity` = **52900** |
| Price | $1,290 **per box** | `regular_price` = **$1,290** |

The shop then offers *52,900 items at $1,290 each*, so a customer can place an order 1000×
larger than what can be delivered.

This adds an **opt-in** `sync_in_sales_uom` checkbox on **WooCommerce Server**, **off by
default**, so nothing changes for existing sites. When enabled:

- `stock_update`: the summed Bin quantity is divided by the Item's Sales UOM conversion factor
  before being posted (52,900 pieces → 52 boxes).
- `sync_items`: the `Item Price` lookup is filtered by that same UOM, so the published price
  belongs to the published unit.

A new helper, `get_sales_uom_conversion_factor()`, returns `1.0` when the Item has no Sales UOM,
when it equals the Stock UOM, or when no conversion is defined for it — so the common case stays
a no-op even with the setting turned on.

## Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Not breaking: the new field defaults to `0` and the helper returns `1.0` for Items without a
distinct Sales UOM.

## Tests

- [x] [Unit Tests](https://frappeframework.com/docs/user/en/guides/automated-testing/unit-testing) have been updated or added, as required
- [x] No UI Tests necessary

Four unit tests were added for `get_sales_uom_conversion_factor()`, covering: no Sales UOM,
Sales UOM equal to Stock UOM, a real conversion, and a Sales UOM missing from the conversion
table.

Verified manually on **ERPNext 15.119.0 / Frappe 15.117.0** with `woocommerce_fusion` 1.17.3:

```
▸ Item sold by BOX of 1,000 pieces — 52,900 pieces in stock
   setting off:  stock_quantity = 52,900
   setting on:   stock_quantity = 52          ← corrected

▸ Control Item sold by PIECE — 250 pieces in stock
   setting off:  stock_quantity = 250
   setting on:   stock_quantity = 250         ← unchanged, no-op
```

Existing suites still pass: `test_stock_update` (3), `test_sync_items` (9),
`test_sync_item_prices` (14).

## Checklist:

- [x] My code follows [Naming Guidelines](https://github.com/frappe/erpnext/wiki/Naming-Guidelines)
- [x] No Form changes beyond the single new checkbox, placed next to the stock sync settings
- [x] My code follows the [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards) of this project
- [x] My code follows the [Code Security Guidelines](https://github.com/frappe/erpnext/wiki/Code-Security-Guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The new field carries a description explaining when to use it
- [x] All business logic and validations are on the server-side
- [x] No patches are necessary — the new field is additive with a `0` default

---

Happy to adjust the naming, the field placement, or the default behaviour if you'd prefer a
different approach.

One unrelated question while I'm here: I couldn't find a license file in the repository — could
you confirm which license the project is released under?
