### PR TITLE
fix(tax): apply per-item Item Tax Template on the template sync path …

### DIFF
--- a/woocommerce_fusion/tasks/sync_sales_orders.py
+++ b/woocommerce_fusion/tasks/sync_sales_orders.py
@@ -760,6 +760,7 @@ class SynchroniseSalesOrder(SynchroniseWooCommerce):
 				found_item = frappe.get_doc("Item", item_codes[0].parent) if item_codes else None
 
 			rate = item.get("price")
+			item_tax_template = None
 			# If we are applying a Sales Taxes and Charges Template (as opposed to Actual Tax), then we need to
 			# determine if the item price should include tax or not
 			if wc_server.enable_tax_lines_sync and not wc_server.use_actual_tax_type:
@@ -769,6 +770,10 @@ class SynchroniseSalesOrder(SynchroniseWooCommerce):
 				)
 				if tax_template.taxes[0].included_in_print_rate:
 					rate = get_tax_inc_price_for_woocommerce_line_item(item)
+				# Resolve this line's WooCommerce tax rate to an Item Tax Template, so that a mixed-rate
+				# order is taxed per item instead of at the single order-level template rate (issue #259).
+				# With no map configured/matched, item_tax_template stays None and behaviour is unchanged.
+				item_tax_template = get_item_tax_template_for_line_item(wc_server, item)
 
 			new_sales_order_line = {
 				"item_code": found_item.name,
@@ -780,6 +785,9 @@ class SynchroniseSalesOrder(SynchroniseWooCommerce):
 				"warehouse": wc_server.warehouse,
 				"discount_percentage": 100 if item.get("price") == 0 else 0,
 			}
+
+			if item_tax_template:
+				new_sales_order_line["item_tax_template"] = item_tax_template
 
 			# Process Order Item Line Field Mappings
 			self.set_sales_order_item_fields(woocommerce_order_line_item=item, so_item=new_sales_order_line)
@@ -1230,6 +1238,45 @@ def add_tax_details(sales_order, price, desc, tax_account_head):
 			"description": desc,
 		},
 	)
+
+
+def get_item_tax_template_for_line_item(wc_server, line_item):
+	"""
+	Resolve a WooCommerce order line item to an ERPNext Item Tax Template using the `tax_rate_map`
+	child table on WooCommerce Server. Matching is attempted first on the tax rate ids in the line
+	item's `taxes` array, then on its `tax_class` slug.
+
+	Returns the mapped Item Tax Template name, or None when no map is configured or none of the
+	line's rates match a map entry. In that case the caller keeps the existing behaviour (the single
+	order-level Sales Taxes and Charges Template), so single-rate setups are unaffected. See #259.
+	"""
+	tax_rate_map = getattr(wc_server, "tax_rate_map", None)
+	if not tax_rate_map:
+		return None
+
+	# Candidate keys in priority order: WooCommerce tax rate ids on the line, then the tax_class slug
+	candidate_keys = [
+		str(tax.get("id")) for tax in (line_item.get("taxes") or []) if tax.get("id") is not None
+	]
+	if line_item.get("tax_class"):
+		candidate_keys.append(str(line_item.get("tax_class")))
+
+	lookup = {
+		str(row.woocommerce_tax_rate_id): row.item_tax_template
+		for row in tax_rate_map
+		if row.woocommerce_tax_rate_id and row.item_tax_template
+	}
+	for key in candidate_keys:
+		if key in lookup:
+			return lookup[key]
+
+	# A map is configured but nothing matched this line: keep default behaviour, but make it visible.
+	frappe.logger("woocommerce_fusion").warning(
+		"No WooCommerce Tax Rate Map entry matched line item "
+		f"{line_item.get('id') or line_item.get('product_id')} (tax keys {candidate_keys}); "
+		"falling back to the order-level tax template."
+	)
+	return None
 
 
 def get_tax_inc_price_for_woocommerce_line_item(line_item: dict):

--- a/woocommerce_fusion/tasks/test_sync_sales_orders.py
+++ b/woocommerce_fusion/tasks/test_sync_sales_orders.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import Mock, call, patch
 
 import frappe
@@ -12,6 +13,7 @@ from woocommerce_fusion.tasks.sync_sales_orders import (
 	find_existing_contact,
 	find_existing_customer,
 	get_customer_selling_price_list,
+	get_item_tax_template_for_line_item,
 )
 from woocommerce_fusion.woocommerce.woocommerce_api import (
 	generate_woocommerce_record_name_from_domain_and_id,
@@ -865,3 +867,52 @@ def create_gl_account_for_bank(account_name="_Test Bank"):
 		pass
 
 	return frappe.get_doc("Account", {"account_name": account_name, "company": get_default_company()})
+
+
+def _tax_rate_map(*pairs):
+	"""Build a fake `tax_rate_map` child table: pairs of (woocommerce_tax_rate_id, item_tax_template)."""
+	return [
+		SimpleNamespace(woocommerce_tax_rate_id=rate_id, item_tax_template=template)
+		for rate_id, template in pairs
+	]
+
+
+class TestGetItemTaxTemplateForLineItem(FrappeTestCase):
+	"""Unit tests for the WooCommerce tax rate -> Item Tax Template resolution (issue #259)."""
+
+	def test_matches_by_woocommerce_tax_rate_id(self):
+		wc_server = SimpleNamespace(tax_rate_map=_tax_rate_map(("1", "VAT 10% - SC"), ("2", "VAT 20% - SC")))
+		line_item = {"taxes": [{"id": 2, "total": "15.30"}], "tax_class": ""}
+		self.assertEqual(get_item_tax_template_for_line_item(wc_server, line_item), "VAT 20% - SC")
+
+	def test_rate_id_is_matched_as_string(self):
+		# WooCommerce sends the rate id as an int; the map stores a Data (string) value.
+		wc_server = SimpleNamespace(tax_rate_map=_tax_rate_map(("7", "VAT 10% - SC")))
+		line_item = {"taxes": [{"id": 7, "total": "1.00"}]}
+		self.assertEqual(get_item_tax_template_for_line_item(wc_server, line_item), "VAT 10% - SC")
+
+	def test_falls_back_to_tax_class_slug(self):
+		wc_server = SimpleNamespace(tax_rate_map=_tax_rate_map(("reduced-rate", "VAT 10% - SC")))
+		line_item = {"taxes": [], "tax_class": "reduced-rate"}
+		self.assertEqual(get_item_tax_template_for_line_item(wc_server, line_item), "VAT 10% - SC")
+
+	def test_rate_id_takes_priority_over_tax_class(self):
+		wc_server = SimpleNamespace(
+			tax_rate_map=_tax_rate_map(("2", "VAT 20% - SC"), ("reduced-rate", "VAT 10% - SC"))
+		)
+		line_item = {"taxes": [{"id": 2}], "tax_class": "reduced-rate"}
+		self.assertEqual(get_item_tax_template_for_line_item(wc_server, line_item), "VAT 20% - SC")
+
+	def test_no_map_returns_none(self):
+		self.assertIsNone(
+			get_item_tax_template_for_line_item(SimpleNamespace(tax_rate_map=[]), {"taxes": []})
+		)
+		self.assertIsNone(
+			get_item_tax_template_for_line_item(SimpleNamespace(tax_rate_map=None), {"taxes": []})
+		)
+
+	def test_map_configured_but_no_match_returns_none(self):
+		# Unchanged (order-level template) behaviour is preserved when nothing matches.
+		wc_server = SimpleNamespace(tax_rate_map=_tax_rate_map(("99", "VAT 20% - SC")))
+		line_item = {"taxes": [{"id": 2}], "tax_class": "", "id": 5}
+		self.assertIsNone(get_item_tax_template_for_line_item(wc_server, line_item))

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.json
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server/woocommerce_server.json
@@ -43,6 +43,7 @@
   "tax_account",
   "use_actual_tax_type",
   "sales_taxes_and_charges_template",
+  "tax_rate_map",
   "column_break_4b4vn",
   "f_n_f_account",
   "f_n_f_tax_account",
@@ -214,6 +215,14 @@
    "label": "Sales Taxes and Charges Template",
    "mandatory_depends_on": "eval: doc.enable_tax_lines_sync && !doc.use_actual_tax_type;",
    "options": "Sales Taxes and Charges Template"
+  },
+  {
+   "depends_on": "eval:doc.enable_tax_lines_sync && !doc.use_actual_tax_type",
+   "description": "Map WooCommerce tax rates to ERPNext Item Tax Templates so mixed-rate orders are taxed per item (issue #259). Empty = single order-level template (unchanged behaviour).",
+   "fieldname": "tax_rate_map",
+   "fieldtype": "Table",
+   "label": "WooCommerce Tax Rate Map",
+   "options": "WooCommerce Server Tax Rate"
   },
   {
    "fieldname": "secret",

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server_tax_rate/woocommerce_server_tax_rate.json
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server_tax_rate/woocommerce_server_tax_rate.json
@@ -1,0 +1,51 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-08-14 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "woocommerce_tax_rate_id",
+  "item_tax_template",
+  "tax_account"
+ ],
+ "fields": [
+  {
+   "description": "WooCommerce tax rate identifier: the <code>id</code> of an entry in a line item's <code>taxes</code> array, or the line item's <code>tax_class</code> slug.",
+   "fieldname": "woocommerce_tax_rate_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "WooCommerce Tax Rate ID / Tax Class",
+   "reqd": 1
+  },
+  {
+   "description": "Applied per Sales Order Item on the template tax path (<code>use_actual_tax_type = 0</code>).",
+   "fieldname": "item_tax_template",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item Tax Template",
+   "options": "Item Tax Template"
+  },
+  {
+   "description": "Reserved for the actual tax path (per-rate tax account). Not used by the template path.",
+   "fieldname": "tax_account",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Tax Account",
+   "options": "Account"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-08-14 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "WooCommerce",
+ "name": "WooCommerce Server Tax Rate",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/woocommerce_fusion/woocommerce/doctype/woocommerce_server_tax_rate/woocommerce_server_tax_rate.py
+++ b/woocommerce_fusion/woocommerce/doctype/woocommerce_server_tax_rate/woocommerce_server_tax_rate.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Dirk van der Laarse and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class WooCommerceServerTaxRate(Document):
+	pass


### PR DESCRIPTION
 ### What & why
  
  Fixes #259 (template-path half). On the **Sales Taxes and Charges Template** path (`use_actual_tax_type = 0`), `WooCommerceOrdersSync.set_items_in_sales_order` (`sync_sales_orders.py:757-762`) set only the order-level template and never set
  `item_tax_template` on the Sales Order Item rows. The single "On Net Total" row was therefore applied to the whole net total, so a **mixed-rate order** (e.g. an Austrian order mixing 10% and 20% items) was taxed at one rate and the ERPNext grand total
  no longer matched WooCommerce.
  
  This is independent of the v16 shared-tax-account guard added in #254 / #255 (that one is about a duplicate account head zeroing the calculated VAT; this is about per-item rates).
  
  ### Change
  
  - New child table **`WooCommerce Server Tax Rate`** on WooCommerce Server (field `tax_rate_map`): `woocommerce_tax_rate_id` (the `id` from a line item's `taxes[]`, or its `tax_class` slug) → `item_tax_template` (used here) and `tax_account` (reserved
  for the actual path). Naming follows the existing `WooCommerce Server *` child tables; the field is only shown in template mode.
  - On the template path, `get_item_tax_template_for_line_item()` resolves the line's WooCommerce tax rate (rate id first, then `tax_class`) to an Item Tax Template and sets it on the Sales Order Item, so ERPNext computes tax **per item**.
  - **Fallback:** when no map is configured or nothing matches, behaviour is unchanged (single order-level template), so existing single-rate setups are unaffected; a partial miss logs a warning. The **actual-tax path and v15 behaviour are untouched.**
  
  ### Test evidence
  
  Verified on **ERPNext v16.28.0** with the mixed basket from #259 (our own real-world case): 10% book net 152.73 + 20% item net 76.50; correct target net 229.23, VAT 30.57, grand 259.80.
  
  | Scenario | Net | VAT | Grand total |
  |---|---|---|---|
  | Before (order-level 20%, no per-item ITT) | 229.23 | **45.85** ❌ | 275.08 |
  | After — shared VAT account | 229.23 | **30.57** ✅ | 259.80 |
  | After — separate 10%/20% accounts (full-coverage ITTs) | 229.23 | **30.57** ✅ (15.27 + 15.30) | 259.80 |
  
  The corrected amount matches WooCommerce to the cent; with distinct accounts and Item Tax Templates that cover both heads, the per-rate account attribution is correct too. Added unit tests for the resolver (rate-id / tax_class / priority / fallback).
  
  ### Note on configuration
  
  Correct amounts require the mapped Item Tax Templates to be modelled per ERPNext convention (each ITT covering every tax head that appears on the order; `0` for the non-applicable one when using separate accounts). This PR covers the **template path** 
  (acceptance criterion 1 in #259). The actual-path / per-rate-account grouping (criterion 2) is left for a follow-up.
  
  ### Checklist
  
  - [x] Unit tests added (`TestGetItemTaxTemplateForLineItem`)
  - [x] `ruff check` / `ruff format` clean (line-length 110, tab indent)
  - [x] No migration patch required (additive child DocType + field)
  - [x] Backwards compatible (fallback = current behaviour)
  - [ ] Integration test for a mixed-rate order — happy to add following `test_integration_so_sync.py`; it needs two WC products at different tax classes in the test shop, so I'd value a pointer on the preferred fixture setup.
