### PR TITLE
fix: look up Item Price by item_code, not item_name

### DIFF
--- a/woocommerce_fusion/tasks/sync_items.py
+++ b/woocommerce_fusion/tasks/sync_items.py
@@ -737,7 +737,7 @@ def get_item_price_rate(item: ERPNextItemToSync):
 	if wc_server.enable_price_list_sync:
 		item_prices = frappe.get_all(
 			"Item Price",
-			filters={"item_code": item.item.item_name, "price_list": wc_server.price_list},
+			filters={"item_code": item.item.item_code, "price_list": wc_server.price_list},
 			fields=["price_list_rate", "valid_upto"],
 		)
 		return next(
@@ -768,7 +768,7 @@ def get_item_sale_price_data(item: ERPNextItemToSync) -> frappe._dict | None:
 
 	item_prices = frappe.get_all(
 		"Item Price",
-		filters={"item_code": item.item.item_name, "price_list": wc_server.sales_price_list},
+		filters={"item_code": item.item.item_code, "price_list": wc_server.sales_price_list},
 		fields=["price_list_rate", "valid_from", "valid_upto"],
 	)
 	return next(


### PR DESCRIPTION
Fixes #258 — reopening the report there, since the auto-close came from an unrelated commit.

`Item Price.item_code` is a Link to `Item`, so it holds the **item code**. Both lookups were passing `item_name`, which matches nothing whenever an Item's name differs from its code — the normal case for any catalogue that uses SKUs.

The failure is silent: no exception, the lookup returns `None`, and the product is published with `regular_price = 0`.

Two call sites, both changed:

| | Function | Syncs |
|---|---|---|
| `sync_items.py` | `get_item_price_rate()` | The regular price |
| `sync_items.py` | `get_item_sale_price_data()` | The **sale** price |

Fixing only the first one leaves sale prices at 0, which is why both are here.

### Verified

Reproduced and confirmed on **ERPNext 15.119.0 / Frappe 15.117.0, woocommerce_fusion 1.17.3, WooCommerce 11.0.1** against a live store: an Item with `item_code = "VASO-PLA-12-90"` and a different `item_name` published at `0`; with this change it carries its Item Price rate.

I haven't re-run it against `v1.18.0` — the two call sites are unchanged there, but worth a second pair of eyes.

Items whose name equals their code — the default when you let ERPNext name Items automatically — are unaffected, which is likely why this hasn't surfaced before.

Separate from #257, which is an opt-in feature rather than a bug fix.
