### PR TITLE
fix: only add missing Item Attribute values during sync

### DIFF
--- a/woocommerce_fusion/tasks/sync_items.py
+++ b/woocommerce_fusion/tasks/sync_items.py
@@ -763,17 +763,21 @@ class SynchroniseItem(SynchroniseWooCommerce):
 					wc_attribute["options"] if wc_product.type == "variable" else [wc_attribute["option"]]
 				)
 
-				# If no attributes values exist, or attribute values exist already but are different, remove and update them
-				if len(item_attribute.item_attribute_values) == 0 or (
-					len(item_attribute.item_attribute_values) > 0
-					and set(options)
-					!= set([val.attribute_value for val in item_attribute.item_attribute_values])
-				):
-					item_attribute.item_attribute_values = []
-					for option in options:
-						row = item_attribute.append("item_attribute_values")
-						row.attribute_value = option
-						row.abbr = option.replace(" ", "")
+				# Only ADD values that are missing; never remove or rename existing ones.
+				#
+				# The previous implementation replaced the whole `item_attribute_values`
+				# table with `options`. For a WooCommerce *variation*, `options` holds a
+				# single value, so syncing one variation reduced the entire ERPNext Item
+				# Attribute to that one value, orphaning every other variant that used it.
+				# It also rewrote `abbr` for existing values, which breaks the item codes
+				# already generated from them.
+				existing_values = {val.attribute_value for val in item_attribute.item_attribute_values}
+				for option in options:
+					if option in existing_values:
+						continue
+					row = item_attribute.append("item_attribute_values")
+					row.attribute_value = option
+					row.abbr = option.replace(" ", "")
 
 				item_attribute.flags.ignore_mandatory = True
 				if not item_attribute.name:

--- a/woocommerce_fusion/tasks/test_sync_items.py
+++ b/woocommerce_fusion/tasks/test_sync_items.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, Mock, call, patch
 
 import frappe
@@ -424,3 +425,83 @@ class TestRunItemSyncFromHook(UnitTestCase):
 				enqueue_call.kwargs.get("enqueue_after_commit"),
 				f"{enqueue_call.args[0]} is enqueued before the transaction commits",
 			)
+
+
+@patch("woocommerce_fusion.tasks.sync_items.run_item_sync")
+@patch.object(SynchroniseItem, "set_sync_hash")
+class TestCreateOrUpdateItemAttributes(UnitTestCase):
+	"""Regression tests for #243: syncing must never drop existing Item Attribute values."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+
+	@staticmethod
+	def _item_attribute(values):
+		"""An in-memory Item Attribute pre-populated with `values` as (attribute_value, abbr)."""
+		attribute = frappe.get_doc({"doctype": "Item Attribute"})
+		attribute.attribute_name = "Size"
+		attribute.name = "Size"
+		for attribute_value, abbr in values:
+			row = attribute.append("item_attribute_values")
+			row.attribute_value = attribute_value
+			row.abbr = abbr
+		return attribute
+
+	def _run_sync(self, wc_product, attribute):
+		sync = SynchroniseItem(servers=Mock())
+		with patch("frappe.db.exists", return_value=True), patch(
+			"frappe.get_doc", return_value=attribute
+		), patch.object(attribute, "save"), patch.object(attribute, "insert"):
+			sync.create_or_update_item_attributes(wc_product)
+		return attribute
+
+	def test_syncing_a_variation_keeps_the_other_attribute_values(
+		self, mock_set_sync_hash, mock_run_item_sync
+	):
+		"""
+		A WooCommerce variation reports a single option. Syncing it must not reduce the
+		ERPNext Item Attribute to that one value, which would orphan every other variant.
+		"""
+		attribute = self._item_attribute([("Small", "S"), ("Medium", "M"), ("Large", "L")])
+
+		wc_product = Mock()
+		wc_product.type = "variation"
+		wc_product.attributes = json.dumps([{"name": "Size", "option": "Medium"}])
+
+		self._run_sync(wc_product, attribute)
+
+		self.assertEqual(
+			[row.attribute_value for row in attribute.item_attribute_values],
+			["Small", "Medium", "Large"],
+		)
+
+	def test_existing_abbreviations_are_not_rewritten(self, mock_set_sync_hash, mock_run_item_sync):
+		"""
+		`abbr` feeds generated item codes, so an existing value must keep its abbreviation
+		even when WooCommerce reports the same option again.
+		"""
+		attribute = self._item_attribute([("Small", "SM")])
+
+		wc_product = Mock()
+		wc_product.type = "variable"
+		wc_product.attributes = json.dumps([{"name": "Size", "options": ["Small"]}])
+
+		self._run_sync(wc_product, attribute)
+
+		self.assertEqual(len(attribute.item_attribute_values), 1)
+		self.assertEqual(attribute.item_attribute_values[0].abbr, "SM")
+
+	def test_new_options_are_added(self, mock_set_sync_hash, mock_run_item_sync):
+		"""Values that WooCommerce reports and ERPNext does not have yet are appended."""
+		attribute = self._item_attribute([("Small", "S")])
+
+		wc_product = Mock()
+		wc_product.type = "variable"
+		wc_product.attributes = json.dumps([{"name": "Size", "options": ["Small", "Large"]}])
+
+		self._run_sync(wc_product, attribute)
+
+		self.assertEqual(
+			[row.attribute_value for row in attribute.item_attribute_values], ["Small", "Large"]
+		)


### PR DESCRIPTION
## Description

Fixes #243.

`create_or_update_item_attributes` replaced the whole `item_attribute_values` table with the options reported by WooCommerce:

```python
item_attribute.item_attribute_values = []
for option in options:
    row = item_attribute.append("item_attribute_values")
    row.attribute_value = option
    row.abbr = option.replace(" ", "")
```

For a WooCommerce **variation**, `options` holds a *single* value. Syncing one variation therefore reduced the entire ERPNext Item Attribute to that one value, orphaning every other variant that used it. It also rewrote `abbr` for values that already existed, which breaks the item codes generated from them.

This matches what #243 reports — the error surfaces on products that don't even use the value being complained about, because the whole attribute is being rewritten.

### Reproduced independently

On ERPNext v16.31.1 with a distributor catalogue (cups by size × lid diameter), syncing a single sales order containing one variation:

| | Before sync | After sync |
|---|---|---|
| `Ounces` | 6 values | **1 value** |
| `Mouth` | `62, 78, 80, 90, 98` | **`78mm, 90mm, 98mm`** |

`62 mm` and `80 mm` disappeared — the values used by two existing variants — and every abbreviation was rewritten.

⚠️ Worth noting: the workaround ERPNext's own error message suggests, *"Allow Rename Attribute Value"*, is what lets the damage through. With it off the sync fails loudly; with it on the data is silently corrupted.

### The change

Only append values that are missing. Never remove, never rename. This is the expected behaviour described in the issue:

> Existing attribute values should not be modified. Only missing values should be added (if needed).

## Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Tests

- [x] [Unit Tests](https://frappeframework.com/docs/user/en/guides/automated-testing/unit-testing) have been updated or added, as required
- [ ] [UI Tests](https://frappeframework.com/docs/user/en/ui-testing) have been updated or added, as required

Three regression tests in `test_sync_items.py`:

- `test_syncing_a_variation_keeps_the_other_attribute_values` — the reported bug
- `test_existing_abbreviations_are_not_rewritten` — `abbr` feeds generated item codes
- `test_new_options_are_added` — genuinely new options still get appended

All pass, and the full `test_sync_items` module (13 tests) stays green.

## Checklist:

- [x] My code follows [Naming Guidelines](https://github.com/frappe/erpnext/wiki/Naming-Guidelines) (DocType, Field and Variable naming)
- [x] No Form changes
- [x] My code follows the [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards) of this project
- [x] My code follows the [Code Security Guidelines](https://github.com/frappe/erpnext/wiki/Code-Security-Guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] No documentation changes required
- [x] All business logic and validations are on the server-side
- [x] No patches are necessary — the fix only changes future sync behaviour. Attributes already damaged by earlier syncs need to be restored by hand, since the original values are not recoverable from WooCommerce.
