### PR TITLE
fix: store the WooCommerce status label when syncing Sales Order status

### DIFF
--- a/woocommerce_fusion/overrides/selling/sales_order.py
+++ b/woocommerce_fusion/overrides/selling/sales_order.py
@@ -8,6 +8,9 @@ from frappe.model.naming import get_default_naming_series, make_autoname
 from frappe.utils import cstr
 
 from woocommerce_fusion.tasks.sync_sales_orders import run_sales_order_sync
+from woocommerce_fusion.woocommerce.doctype.woocommerce_order.woocommerce_order import (
+	WC_ORDER_STATUS_MAPPING_REVERSE,
+)
 from woocommerce_fusion.woocommerce.woocommerce_api import (
 	generate_woocommerce_record_name_from_domain_and_id,
 )
@@ -77,12 +80,23 @@ class CustomSalesOrder(SalesOrder):
 					None,
 				)
 				if mapping:
-					if self.woocommerce_status != mapping.woocommerce_sales_order_status:
+					# `woocommerce_status` stores the connector's display label
+					# ("Processing"), while the status map stores the WooCommerce
+					# status key ("processing"). Writing the key straight into the
+					# field leaves a value that is not in the field's options, and
+					# every later save of that Sales Order fails validation with
+					# "Woocommerce Status cannot be 'processing'", which blocks the
+					# order sync entirely.
+					wc_status_label = WC_ORDER_STATUS_MAPPING_REVERSE.get(
+						mapping.woocommerce_sales_order_status,
+						mapping.woocommerce_sales_order_status,
+					)
+					if self.woocommerce_status != wc_status_label:
 						frappe.db.set_value(
 							"Sales Order",
 							self.name,
 							"woocommerce_status",
-							mapping.woocommerce_sales_order_status,
+							wc_status_label,
 						)
 						frappe.enqueue(
 							run_sales_order_sync,

--- a/woocommerce_fusion/overrides/selling/test_sales_order_status_sync.py
+++ b/woocommerce_fusion/overrides/selling/test_sales_order_status_sync.py
@@ -1,0 +1,85 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import UnitTestCase
+
+from woocommerce_fusion.overrides.selling.sales_order import CustomSalesOrder
+
+
+class TestSalesOrderStatusSync(UnitTestCase):
+	"""
+	The Sales Order Status Map stores WooCommerce status keys ("processing"), while the
+	`woocommerce_status` field stores the connector's labels ("Processing"). Writing the
+	key straight into the field leaves a value outside the field's options, and every
+	later save of that Sales Order fails validation, which blocks the order sync.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+
+	@staticmethod
+	def _sales_order(status, woocommerce_status=None):
+		sales_order = frappe.get_doc({"doctype": "Sales Order"})
+		sales_order.name = "SO-0001"
+		sales_order.status = status
+		sales_order.woocommerce_status = woocommerce_status
+		sales_order.woocommerce_id = 1
+		sales_order.woocommerce_server = "site1.example.com"
+		return sales_order
+
+	@staticmethod
+	def _wc_server(erpnext_status, woocommerce_status):
+		return frappe._dict(
+			enable_so_status_sync=1,
+			sales_order_status_map=[
+				frappe._dict(
+					erpnext_sales_order_status=erpnext_status,
+					woocommerce_sales_order_status=woocommerce_status,
+				)
+			],
+		)
+
+	def _run_on_change(self, sales_order, wc_server):
+		with patch(
+			"woocommerce_fusion.overrides.selling.sales_order.frappe.get_cached_doc",
+			return_value=wc_server,
+		), patch(
+			"woocommerce_fusion.overrides.selling.sales_order.frappe.db.set_value"
+		) as mock_set_value, patch(
+			"woocommerce_fusion.overrides.selling.sales_order.frappe.enqueue"
+		) as mock_enqueue:
+			CustomSalesOrder.on_change(sales_order)
+		return mock_set_value, mock_enqueue
+
+	def test_status_sync_stores_the_label_not_the_woocommerce_key(self):
+		"""The field must receive "Processing", never the raw "processing"."""
+		mock_set_value, _ = self._run_on_change(
+			self._sales_order("To Deliver and Bill"),
+			self._wc_server("To Deliver and Bill", "processing"),
+		)
+		mock_set_value.assert_called_once_with(
+			"Sales Order", "SO-0001", "woocommerce_status", "Processing"
+		)
+
+	def test_status_sync_is_a_no_op_when_the_label_already_matches(self):
+		"""
+		Comparing against the raw key made the field look out of date on every change,
+		re-queueing a sync each time. Comparing against the label stops that.
+		"""
+		mock_set_value, mock_enqueue = self._run_on_change(
+			self._sales_order("Completed", woocommerce_status="Shipped"),
+			self._wc_server("Completed", "completed"),
+		)
+		mock_set_value.assert_not_called()
+		mock_enqueue.assert_not_called()
+
+	def test_unknown_woocommerce_status_is_passed_through(self):
+		"""A custom status with no entry in the mapping must not be silently dropped."""
+		mock_set_value, _ = self._run_on_change(
+			self._sales_order("On Hold"),
+			self._wc_server("On Hold", "awaiting-restock"),
+		)
+		mock_set_value.assert_called_once_with(
+			"Sales Order", "SO-0001", "woocommerce_status", "awaiting-restock"
+		)


### PR DESCRIPTION
## Description

`CustomSalesOrder.on_change` (`overrides/selling/sales_order.py`) writes the Sales Order Status Map value straight into the `woocommerce_status` field:

```python
frappe.db.set_value(
    "Sales Order", self.name, "woocommerce_status",
    mapping.woocommerce_sales_order_status,   # "processing"
)
```

The map holds **WooCommerce status keys** (`processing`, `completed`), while `woocommerce_status` has the connector's **labels** as its options (`Processing`, `Shipped`, …). The field is left holding a value that is not in its own options.

That is not cosmetic. Every later save of that Sales Order then fails:

```
ValidationError: Woocommerce Status cannot be "processing".
It must be one of "", "Pending Payment", "On hold", "Failed", "Cancelled", "Processing", …
```

**So turning on `enable_so_status_sync` stops order sync from working entirely.**

### Reproduced on ERPNext v16.31.1 + woocommerce_fusion 2.3.0

Same store, same order, only the flag changed:

```
enable_so_status_sync = 1  →  ValidationError, order sync fails
enable_so_status_sync = 0  →  OK
```

With this patch and the flag back on, the same order syncs, and the field holds a label:

```
SYNC: OK
woocommerce_status = 'Shipped'  →  after on_change  →  'Processing'
```

### The change

`WC_ORDER_STATUS_MAPPING_REVERSE` already exists for exactly this translation, so the fix uses it. It falls back to the raw value, so a custom WooCommerce status with no entry in the mapping is still stored rather than dropped.

There is a second, quieter effect: the old code compared `self.woocommerce_status` (a label) against the map's key, so they never matched and **every** `on_change` re-queued a sync. Comparing like with like stops that.

## Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Tests

- [x] [Unit Tests](https://frappeframework.com/docs/user/en/guides/automated-testing/unit-testing) have been updated or added, as required
- [ ] [UI Tests](https://frappeframework.com/docs/user/en/ui-testing) have been updated or added, as required

Three tests in a new `test_sales_order_status_sync.py`:

- `test_status_sync_stores_the_label_not_the_woocommerce_key` — the reported bug
- `test_status_sync_is_a_no_op_when_the_label_already_matches` — no more redundant re-queueing
- `test_unknown_woocommerce_status_is_passed_through` — custom statuses survive

They live in their own module on purpose: `test_sales_order.py` declares `test_dependencies = ["Company", "Customer", "Warehouse"]`, which pulls in records (and the `payments` app, via Payment Gateway) that these pure-mock tests do not need.

## Checklist:

- [x] My code follows [Naming Guidelines](https://github.com/frappe/erpnext/wiki/Naming-Guidelines)
- [x] No Form changes
- [x] My code follows the [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards) of this project
- [x] My code follows the [Code Security Guidelines](https://github.com/frappe/erpnext/wiki/Code-Security-Guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] No documentation changes required
- [x] All business logic and validations are on the server-side
- [x] No patches are necessary — sites that already ran with the flag on may hold a raw key in `woocommerce_status`; it is corrected on the next status change, and a migration patch felt heavier than the problem. Happy to add one if you prefer.
